### PR TITLE
Revert operator disablement and modify MGO to play nice with new one-time upload-only tokens

### DIFF
--- a/build/bin/upload
+++ b/build/bin/upload
@@ -30,37 +30,13 @@ tar caf "$must_gather_upload/${CSP_FILENAME}" $must_gather_output/
 
 echo "Uploading '${CSP_FILENAME}' to Red Hat Customer SFTP Server for case ${caseid}"
 
-REMOTE_DIR=/users/${username}
 REMOTE_FILENAME=${caseid}_${CSP_FILENAME}
-
-# check login
-echo "Checking login credentials..."
-export SSHPASS=${password}
-sshpass -e sftp ${SFTP_OPTIONS} - ${username}@${FTP_HOST} << EOF
-    bye
-EOF
-
-if [ $? -eq 0 ];
-then
-  echo "Successfully logged into Red Hat SFTP server!"
-else
-  echo "Error: Login failed to Red Hat Customer SFTP Server."
-  exit 1
-fi
-
-# ensure remote directory exists and ignore errors since ftp doesn't support 'mkdir -p'
-echo "Ensuring remote directory exists..."
-set +e
-sshpass -e sftp ${SFTP_OPTIONS} - ${username}@${FTP_HOST} << EOF
-    mkdir ${REMOTE_DIR}
-    bye
-EOF
-set -e
 
 # upload file and detect any erros
 echo "Uploading ${CSP_FILE}..."
+export SSHPASS=${password}
 sshpass -e sftp ${SFTP_OPTIONS} - ${username}@${FTP_HOST} << EOF
-    put ${CSP_FILE} ${REMOTE_DIR}/${REMOTE_FILENAME}
+    put ${CSP_FILE} ${REMOTE_FILENAME}
     bye
 EOF
 

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -25,7 +25,6 @@ objects:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
-        managed.openshift.io/disabled-operator: ${REPO_NAME}
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1

--- a/hack/templates/selectorsyncset.yaml
+++ b/hack/templates/selectorsyncset.yaml
@@ -10,5 +10,4 @@ spec:
   clusterDeploymentSelector:
     matchLabels:
       api.openshift.com/managed: "true"
-      managed.openshift.io/disabled-operator: ${REPO_NAME}
   resourceApplyMode: Sync


### PR DESCRIPTION
Because new tokens may only be used one time, and only provide the user with upload permissions, we can no longer check the login credentials before uploading the m-g file, nor can we attempt to mkdir or cd into that dir

Uploading the file immediately upon login (without worrying about directory structures) works to get the file uploaded successfully to the case - see https://access.redhat.com/support/cases/#/case/02715548