### PR TITLE
Ensure we have a DEPLOYED_HASH

### DIFF
--- a/hack/app_sre_create_image_catalog.sh
+++ b/hack/app_sre_create_image_catalog.sh
@@ -38,7 +38,7 @@ if [[ "$REMOVE_UNDEPLOYED" == true ]]; then
     echo "Current deployed production HASH: $DEPLOYED_HASH"
 
     if [[ ! "${DEPLOYED_HASH}" =~ [0-9a-f]{40} ]]; then
-        echo "Error discoving current production deployed HASH"
+        echo "Error discovering current production deployed HASH"
         exit 1
     fi
 

--- a/hack/app_sre_create_image_catalog.sh
+++ b/hack/app_sre_create_image_catalog.sh
@@ -28,8 +28,19 @@ REMOVED_VERSIONS=""
 if [[ "$REMOVE_UNDEPLOYED" == true ]]; then
     DEPLOYED_HASH=$(
         curl -s "https://gitlab.cee.redhat.com/service/app-interface/raw/master/data/services/osd-operators/cicd/saas/saas-${_OPERATOR_NAME}.yaml" | \
-            docker run --rm -i quay.io/app-sre/yq:3.4.1 yq r - "resourceTemplates[*].targets(namespace.\$ref==/services/osd-operators/namespaces/hivep01ue1/${_OPERATOR_NAME}.yml).ref"
+            docker run --rm -i quay.io/app-sre/yq:3.4.1 yq r - "resourceTemplates[*].targets(namespace.\$ref==/services/osd-operators/namespaces/hivep01ue1/cluster-scope.yml).ref"
     )
+
+    # Ensure that our query for the current deployed hash worked
+    # Validate that our DEPLOYED_HASH var isn't empty.
+    # Although we have `set -e` defined the docker container isn't returning
+    # an error and allowing the script to continue
+    echo "Current deployed production HASH: $DEPLOYED_HASH"
+
+    if [[ ! "${DEPLOYED_HASH}" =~ [0-9a-f]{40} ]]; then
+        echo "Error discoving current production deployed HASH"
+        exit 1
+    fi
 
     delete=false
     # Sort based on commit number


### PR DESCRIPTION
APPSRE SAAS files have different schemas depending on if its a Hive operator or not. We are silently failing on attempting to YQ an image from a file that doesn't exist, returning an empty hash.

This causes production catalog builds to look like staging bundles in respect to every version being added to the catalog. 

For prod deploys don't deploy every version, this means on prod deploy there is a large jump from version to version causing CSV issues.

```
env _OPERATOR_NAME=must-gather-operator REMOVE_UNDEPLOYED=true ./hack/app_sre_create_image_catalog.sh production "quay.io/app-sre/must-gather-operator"
 ...
+ [[ true == true ]]                               
++ curl -s https://gitlab.cee.redhat.com/service/app-interface/raw/master/data/services/osd-operators/cicd/saas/saas-must-gather-operator.yaml
++ docker run --rm -i quay.io/app-sre/yq:3.4.1 yq r - 'resourceTemplates[*].targets(namespace.$ref==/services/osd-operators/namespaces/hivep01ue1/cluster-scope.yml).ref'                                                                                     
+ DEPLOYED_HASH=d0662404dda81303760dd34c74fd61e430cc292e
+ echo 'Current deployed production HASH: d0662404dda81303760dd34c74fd61e430cc292e'
Current deployed production HASH: d0662404dda81303760dd34c74fd61e430cc292e                                                                                                                                                                                    
+ [[ ! d0662404dda81303760dd34c74fd61e430cc292e =~ [0-9a-f]{40} ]]
+ exit 0       
```