### PR TITLE
OSD-8230 - adding a timeout to /usr/bin/gather

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -24,7 +24,7 @@ ENV OPERATOR=/usr/local/bin/must-gather-operator \
     USER_NAME=must-gather-operator \
     JOB_TEMPLATE_FILE_NAME=/etc/templates/job.template.yaml
 
-RUN microdnf install tar gzip openssh-clients wget shadow-utils && \
+RUN microdnf install tar gzip openssh-clients wget shadow-utils procps && \
     wget https://download-ib01.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/s/sshpass-1.06-9.el8.x86_64.rpm && \
     rpm -U sshpass-1.06-9.el8.x86_64.rpm && \
     rm -f sshpass-1.06-9.el8.x86_64.rpm && \

--- a/build/bin/upload
+++ b/build/bin/upload
@@ -26,11 +26,16 @@ then
 fi
 
 echo "Archiving files from $must_gather_output to $must_gather_upload/${CSP_FILENAME}"
-tar caf "$must_gather_upload/${CSP_FILENAME}" $must_gather_output/
+tar --ignore-failed-read -caf "$must_gather_upload/${CSP_FILENAME}" $must_gather_output/
 
 echo "Uploading '${CSP_FILENAME}' to Red Hat Customer SFTP Server for case ${caseid}"
 
 REMOTE_FILENAME=${caseid}_${CSP_FILENAME}
+
+if [[ "${internal_user}" == true ]]; then
+  # internal users must upload to a different path on the sftp
+  REMOTE_FILENAME="${username}/${REMOTE_FILENAME}"
+fi
 
 # upload file and detect any erros
 echo "Uploading ${CSP_FILE}..."

--- a/build/templates/job.template.yaml
+++ b/build/templates/job.template.yaml
@@ -19,12 +19,45 @@ spec:
           key: node-role.kubernetes.io/infra
           operator: Exists
       backoffLimit: 6
-      restartPolicy: OnFailure
-      containers:
+      restartPolicy: OnFailure     
+      shareProcessNamespace: true
+      containers:        
+{{- $timeout := .Spec.MustGatherTimeout}}
+{{ range $index, $element := .Spec.MustGatherImages }} 
+      - command:
+        - /bin/bash
+        - -c 
+        - |
+          timeout {{ $timeout }} bash -x -c -- '/usr/bin/gather'
+          status=$?
+          if [[ $status -eq 124 || $status -eq 137 ]]; then
+            echo "Gather timed out."
+            exit 0
+          fi
+        image: {{ $element }}
+        name: gather-{{ $index }}
+        volumeMounts:
+        - mountPath: /must-gather
+          name: must-gather-output
+{{- end }}
       - command:
         - /bin/bash
         - -c
-        - /usr/local/bin/upload
+        - |
+          count=0
+          until [ $count -gt 4 ]
+          do
+            while `pgrep -a gather > /dev/null`
+            do
+              echo "waiting for gathers to complete ..." 
+              sleep 120
+              count=0
+            done
+            echo "no gather is running ($count / 4)"
+            ((count++))
+            sleep 30
+          done
+          /usr/local/bin/upload
         image: quay.io/app-sre/must-gather-operator:latest
         name: upload
         volumeMounts:
@@ -61,16 +94,8 @@ spec:
           value: /must-gather
         - name: must_gather_upload
           value: /must-gather-upload
-      initContainers:
-{{- range $index, $element := .Spec.MustGatherImages }}
-      - command:
-        - /usr/bin/gather
-        image: {{ $element }}
-        name: gather-{{ $index }}
-        volumeMounts:
-        - mountPath: /must-gather
-          name: must-gather-output
-{{- end }}
+        - name: internal_user
+          value: "{{ .Spec.InternalUser }}"
       serviceAccountName: {{ .Spec.ServiceAccountRef.Name }}
       volumes:
       - emptyDir: {}

--- a/deploy/crds/managed.openshift.io_mustgathers.yaml
+++ b/deploy/crds/managed.openshift.io_mustgathers.yaml
@@ -49,6 +49,11 @@ spec:
                       TODO: Add other useful fields. apiVersion, kind, uid?'
                     type: string
                 type: object
+              internalUser:
+                default: true
+                description: A flag to specify if the upload user provided in the  caseManagementAccountSecret
+                  is a RH internal user. See documentation for further information.
+                type: boolean
               mustGatherImages:
                 description: 'The list of must gather images to run, optional, it
                   will default to: $DEFAULT_MUST_GATHER_IMAGE'
@@ -56,6 +61,12 @@ spec:
                   type: string
                 type: array
                 x-kubernetes-list-type: set
+              mustGatherTimeout:
+                description: 'A time limit for gather command to complete a floating
+                  point number with an optional suffix: "s" for seconds (the default),
+                  "m" for minutes, "h" for hours or "d" for days will default to:
+                  $DEFAULT_MUST_GATHER_TIMEOUT'''
+                type: string
               proxyConfig:
                 description: This represents the proxy configuration to be used. If
                   left empty it will default to the cluster-level proxy configuration.

--- a/examples/mustgather_non_internal_user.yaml
+++ b/examples/mustgather_non_internal_user.yaml
@@ -1,0 +1,11 @@
+apiVersion: managed.openshift.io/v1alpha1
+kind: MustGather
+metadata:
+  name: example-mustgather
+spec:
+  caseID: '02527285'
+  caseManagementAccountSecretRef:
+    name: case-management-creds
+  serviceAccountRef:
+    name: must-gather-admin
+  internalUser: false

--- a/examples/mustgather_timeout.yaml
+++ b/examples/mustgather_timeout.yaml
@@ -1,0 +1,11 @@
+apiVersion: managed.openshift.io/v1alpha1
+kind: MustGather
+metadata:
+  name: example-mustgather
+spec:
+  caseID: '02527285'
+  caseManagementAccountSecretRef:
+    name: case-management-creds
+  serviceAccountRef:
+    name: must-gather-admin
+  mustGatherTimeout: "2m"

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	k8s.io/api v0.15.7
 	k8s.io/apimachinery v0.15.7
 	k8s.io/client-go v12.0.0+incompatible
+	k8s.io/code-generator v0.19.4 // indirect
 	k8s.io/kube-openapi v0.0.0-20190918143330-0270cf2f1c1d
 	sigs.k8s.io/controller-runtime v0.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -831,6 +831,7 @@ golang.org/x/tools v0.0.0-20190614205625-5aca471b1d59/go.mod h1:/rFqwRUd4F7ZHNgw
 golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190624180213-70d37148ca0c/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190706070813-72ffa07ba3db/go.mod h1:jcCCGcm9btYwXyDqrUWc6MKQKKGJCWEQ3AfLSRIbEuI=
+golang.org/x/tools v0.0.0-20191018212557-ed542cd5b28a h1:UuQ+70Pi/ZdWHuP4v457pkXeOynTdgd/4enxeIO/98k=
 golang.org/x/tools v0.0.0-20191018212557-ed542cd5b28a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -925,12 +926,14 @@ k8s.io/client-go v0.0.0-20191016111102-bec269661e48 h1:C2XVy2z0dV94q9hSSoCuTPp1K
 k8s.io/client-go v0.0.0-20191016111102-bec269661e48/go.mod h1:hrwktSwYGI4JK+TJA3dMaFyyvHVi/aLarVHpbs8bgCU=
 k8s.io/cloud-provider v0.0.0-20191016115326-20453efc2458/go.mod h1:O5SO5xcgxrjJV9EC9R/47RuBpbk5YX9URDBlg++FA5o=
 k8s.io/cluster-bootstrap v0.0.0-20191016115129-c07a134afb42/go.mod h1:MzCL6kLExQuHruGaqibd8cugC8nw8QRxm3+lzR5l8SI=
+k8s.io/code-generator v0.0.0-20191004115455-8e001e5d1894 h1:NMYlxaF7rYQJk2E2IyrUhaX81zX24+dmoZdkPw0gJqI=
 k8s.io/code-generator v0.0.0-20191004115455-8e001e5d1894/go.mod h1:mJUgkl06XV4kstAnLHAIzJPVCOzVR+ZcfPIv4fUsFCY=
 k8s.io/component-base v0.0.0-20191016111319-039242c015a9/go.mod h1:SuWowIgd/dtU/m/iv8OD9eOxp3QZBBhTIiWMsBQvKjI=
 k8s.io/cri-api v0.0.0-20190828162817-608eb1dad4ac/go.mod h1:BvtUaNBr0fEpzb11OfrQiJLsLPtqbmulpo1fPwcpP6Q=
 k8s.io/csi-translation-lib v0.0.0-20191016115521-756ffa5af0bd/go.mod h1:lf1VBseeLanBpSXD0N9tuPx1ylI8sA0j6f+rckCKiIk=
 k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20190822140433-26a664648505/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
+k8s.io/gengo v0.0.0-20191010091904-7fa3014cb28f h1:eW/6wVuHNZgQJmFesyAxu0cvj0WAHHUuGaLbPcmNY3Q=
 k8s.io/gengo v0.0.0-20191010091904-7fa3014cb28f/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/heapster v1.2.0-beta.1/go.mod h1:h1uhptVXMwC8xtZBYsPXKVi8fpdlYkTs6k949KozGrM=
 k8s.io/helm v2.16.1+incompatible/go.mod h1:LZzlS4LQBHfciFOurYBFkCMTaZ0D1l+p0teMg7TSULI=

--- a/pkg/apis/mustgather/v1alpha1/mustgather_types.go
+++ b/pkg/apis/mustgather/v1alpha1/mustgather_types.go
@@ -33,6 +33,16 @@ type MustGatherSpec struct {
 	// This represents the proxy configuration to be used. If left empty it will default to the cluster-level proxy configuration.
 	// +kubebuilder:validation:Optional
 	ProxyConfig ProxySpec `json:"proxyConfig,omitempty"`
+
+	// A time limit for gather command to complete a floating point number with an optional suffix:
+	// "s" for seconds (the default), "m" for minutes, "h" for hours or "d" for days will default to: $DEFAULT_MUST_GATHER_TIMEOUT'
+	// +kubebuilder:validation:Optional
+	MustGatherTimeout string `json:"mustGatherTimeout,omitempty"`
+
+	// A flag to specify if the upload user provided in the  caseManagementAccountSecret is a RH internal user.
+	// See documentation for further information.
+	// +kubebuilder:default:=true
+	InternalUser bool `json:"internalUser,omitempty"`
 }
 
 // +k8s:openapi-gen=true

--- a/pkg/apis/mustgather/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/mustgather/v1alpha1/zz_generated.openapi.go
@@ -115,6 +115,20 @@ func schema_pkg_apis_mustgather_v1alpha1_MustGatherSpec(ref common.ReferenceCall
 							Ref:         ref("github.com/openshift/must-gather-operator/pkg/apis/mustgather/v1alpha1.ProxySpec"),
 						},
 					},
+					"mustGatherTimeout": {
+						SchemaProps: spec.SchemaProps{
+							Description: "A time limit for gather command to complete a floating point number with an optional suffix: \"s\" for seconds (the default), \"m\" for minutes, \"h\" for hours or \"d\" for days will default to: $DEFAULT_MUST_GATHER_TIMEOUT'",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"internalUser": {
+						SchemaProps: spec.SchemaProps{
+							Description: "A flag to specify if the upload user provided in the  caseManagementAccountSecret is a RH internal user. See documentation for further information.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"caseID", "caseManagementAccountSecretRef"},
 			},

--- a/pkg/controller/mustgather/mustgather_controller.go
+++ b/pkg/controller/mustgather/mustgather_controller.go
@@ -36,6 +36,7 @@ const controllerName = "mustgather-controller"
 const templateFileNameEnv = "JOB_TEMPLATE_FILE_NAME"
 const defaultMustGatherImageEnv = "DEFAULT_MUST_GATHER_IMAGE"
 const defaultMustGatherNamespace = "openshift-must-gather-operator"
+const defaultMustGatherTimeoutENV = "DEFAULT_MUST_GATHER_TIMEOUT"
 
 var log = logf.Log.WithName(controllerName)
 
@@ -46,9 +47,16 @@ func init() {
 		defaultMustGatherImage = "quay.io/openshift/origin-must-gather:latest"
 	}
 	fmt.Println("using default must gather image: " + defaultMustGatherImage)
+
+	defaultMustGatherTimeout, ok = os.LookupEnv(defaultMustGatherTimeoutENV)
+	if !ok {
+		defaultMustGatherTimeout = "0"
+	}
+	fmt.Println("using default gather timeout: " + defaultMustGatherTimeout)
 }
 
 var defaultMustGatherImage string
+var defaultMustGatherTimeout string
 
 var jobTemplate *template.Template
 
@@ -380,6 +388,11 @@ func (r *ReconcileMustGather) IsInitialized(instance *mustgatherv1alpha1.MustGat
 		instance.Spec.MustGatherImages = imageSet.List()
 		initialized = false
 	}
+	if instance.Spec.MustGatherTimeout == "" {
+		instance.Spec.MustGatherTimeout = defaultMustGatherTimeout
+		initialized = false
+	}
+
 	if instance.Spec.ServiceAccountRef.Name == "" {
 		instance.Spec.ServiceAccountRef.Name = "default"
 		initialized = false


### PR DESCRIPTION
This PR proposes a couple of changes.
- The `/usr/local/bin/gather` are executed as full containers, and not initcontainers. This has two major advantages. 
1. Gather from multiple images can run in parallel instead of sequentially 
2. `oc logs` on the `gather` container(s) will now return some logs

- In this parallel gathering approach, the `upload` container needs to be aware of the end of all gathers. This is why all containers are sharing the same process namespace and the `upload` container monitors `gather` processes for termination. 

- The introduction of a timeout for the gathers. This is made available through the MustGather CR in `spec.mustGatherTimeout`. It should protect against hanging `gather` containers. By default, it is not activated. 

- The introduction of a new flag `internalUser` in the MustGather CR to distinguish between users permissions on the sftp at upload. Most CEE users are marked internal, while SREP users aren't.

- Omission of read errors during the tar creation via `--ignore-failed-read`. Currently, the `upload` will fail if it is not able to read all files generated by the `gather`. However, some files such as private keys are deliberately written with restricted permissions. This change will therefore make sure that purposefully restricted files are not get uploaded to the case. 

