### PR TITLE
reassign the value of tmpPod

### DIFF
--- a/pkg/controller/mustgather/mustgather_controller.go
+++ b/pkg/controller/mustgather/mustgather_controller.go
@@ -257,6 +257,7 @@ func (r *ReconcileMustGather) Reconcile(request reconcile.Request) (reconcile.Re
 					log.Error(err, "Failed to list pods", "Namespace", operatorNs, "UID", tmpJob.UID)
 				} else {
 					for _, tmpPod := range podList.Items {
+						tmpPod := tmpPod
 						err = r.GetClient().Delete(context.TODO(), &tmpPod)
 						if err != nil {
 							reqLogger.Error(err, fmt.Sprintf("Failed to delete %s pod", tmpPod.Name))


### PR DESCRIPTION
reassign the value of tmpPod in for loop to prevent  G601: Implicit memory aliasing in for loop when running golangci gosec lint:
`test "/home/linnguye/golangci.yml" = "" || test ! -e "/home/linnguye/golangci.yml" || GOLANGCI_LINT_CACHE="/tmp/golangci-cache" golangci-lint run -c "/home/linnguye/golangci.yml" ./...
pkg/controller/mustgather/mustgather_controller.go:260:50: G601: Implicit memory aliasing in for loop. (gosec)
						err = r.GetClient().Delete(context.TODO(), &tmpPod)
						                                           ^
make: *** [boilerplate/openshift/golang-osd-operator/standard.mk:171: go-check] Error 1
`
Jira card: https://issues.redhat.com/browse/OSD-11458