### PR TITLE
added //nolint:staticcheck to hide package depreciated check

### DIFF
--- a/pkg/controller/mustgather/mustgather_controller_test.go
+++ b/pkg/controller/mustgather/mustgather_controller_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
+	//nolint:staticcheck -- code is tied to a specific controller-runtime version. See OSD-11458
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )


### PR DESCRIPTION
Justification: code is tied to a specific controller-runtime version, security has agree to let this test be hidden. Here's the output when running golangci goesc lint
`pkg/controller/mustgather/mustgather_controller_test.go:16:2: SA1019: package sigs.k8s.io/controller-runtime/pkg/client/fake is deprecated: please use pkg/envtest for testing. This package will be dropped before the v1.0.0 release. Package fake provides a fake client for testing. (staticcheck)
	"sigs.k8s.io/controller-runtime/pkg/client/fake"
`
Jira card: https://issues.redhat.com/browse/OSD-11458