### PR TITLE
OSD-12071 Add annotation to disable global namespace resolution

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -78,6 +78,8 @@ objects:
       metadata:
         name: ${REPO_NAME}
         namespace: openshift-${REPO_NAME}
+        annotations:
+          olm.operatorframework.io/exclude-global-namespace-resolution: 'true'
       spec:
         targetNamespaces:
         - openshift-${REPO_NAME}


### PR DESCRIPTION
This adds an annotation to the OperatorGroup to allow OLM to be more resilient if a catalog source becomes in a bad state.

**References**
https://bugzilla.redhat.com/show_bug.cgi?id=2076323
https://issues.redhat.com/browse/OSD-12071