### PR TITLE
feat: replace namespaces with recommended one

### DIFF
--- a/deploy/03_must-gather-operator.ClusterRoleBinding.yaml
+++ b/deploy/03_must-gather-operator.ClusterRoleBinding.yaml
@@ -5,7 +5,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: must-gather-operator
-  namespace: openshift-must-gather-operator
+  namespace: must-gather-operator
 roleRef:
   kind: ClusterRole
   name: must-gather-operator

--- a/deploy/07_prometheus-k8s.Role.yaml
+++ b/deploy/07_prometheus-k8s.Role.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: prometheus-k8s
-  namespace: openshift-must-gather-operator
+  namespace: must-gather-operator
 rules:
 - apiGroups:
   - ""

--- a/deploy/08_prometheus-k8s.RoleBinding.yaml
+++ b/deploy/08_prometheus-k8s.RoleBinding.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: prometheus-k8s
-  namespace: openshift-must-gather-operator
+  namespace: must-gather-operator
 roleRef:
   kind: Role
   name: prometheus-k8s

--- a/deploy/99_must-gather-operator.Deployment.yaml
+++ b/deploy/99_must-gather-operator.Deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: must-gather-operator
-  namespace: openshift-must-gather-operator
+  namespace: must-gather-operator
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
As mentioned in the README.md the recommended namespace to use is `must-gather-operator`.

https://github.com/openshift/must-gather-operator/blob/4f1fe47a2f29eb22d62f1acc57b1926f7e1baa13/README.md?plain=1#L69

This PR unifies README.md with the `deploy` files.