### PR TITLE
Added logic in job.template to gather audit logs

### DIFF
--- a/api/v1alpha1/mustgather_types.go
+++ b/api/v1alpha1/mustgather_types.go
@@ -44,6 +44,11 @@ type MustGatherSpec struct {
 	// +listType=set
 	MustGatherImages []string `json:"mustGatherImages,omitempty"`
 
+	// A flag to specify if audit logs must be collected
+	// See documentation for further information.
+	// +kubebuilder:default:=false
+	Audit bool `json:"audit,omitempty"`
+
 	// This represents the proxy configuration to be used. If left empty it will default to the cluster-level proxy configuration.
 	// +kubebuilder:validation:Optional
 	ProxyConfig ProxySpec `json:"proxyConfig,omitempty"`

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -14,11 +14,11 @@ import (
 
 func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenAPIDefinition {
 	return map[string]common.OpenAPIDefinition{
-		"github.com/openshift/must-gather-operator/api/v1alpha1.ProxySpec": schema_openshift_must_gather_operator_api_v1alpha1_ProxySpec(ref),
+		"github.com/ehvs/must-gather-operator/api/v1alpha1.ProxySpec": schema_ehvs_must_gather_operator_api_v1alpha1_ProxySpec(ref),
 	}
 }
 
-func schema_openshift_must_gather_operator_api_v1alpha1_ProxySpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_ehvs_must_gather_operator_api_v1alpha1_ProxySpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -14,11 +14,11 @@ import (
 
 func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenAPIDefinition {
 	return map[string]common.OpenAPIDefinition{
-		"github.com/ehvs/must-gather-operator/api/v1alpha1.ProxySpec": schema_ehvs_must_gather_operator_api_v1alpha1_ProxySpec(ref),
+		"github.com/openshift/must-gather-operator/api/v1alpha1.ProxySpec": schema_openshift_must_gather_operator_api_v1alpha1_ProxySpec(ref),
 	}
 }
 
-func schema_ehvs_must_gather_operator_api_v1alpha1_ProxySpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_openshift_must_gather_operator_api_v1alpha1_ProxySpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{

--- a/build/templates/job.template.yaml
+++ b/build/templates/job.template.yaml
@@ -21,14 +21,19 @@ spec:
       backoffLimit: 6
       restartPolicy: OnFailure     
       shareProcessNamespace: true
-      containers:        
+      containers:
+{{- $audit := .Spec.Audit}}        
 {{- $timeout := .Spec.MustGatherTimeout}}
 {{ range $index, $element := .Spec.MustGatherImages }} 
       - command:
         - /bin/bash
         - -c 
         - |
+{{ if $audit }}
+          timeout {{ $timeout }} bash -x -c -- '/usr/bin/gather_audit_logs'
+{{ else }}  
           timeout {{ $timeout }} bash -x -c -- '/usr/bin/gather'
+{{ end }}
           status=$?
           if [[ $status -eq 124 || $status -eq 137 ]]; then
             echo "Gather timed out."

--- a/deploy/crds/managed.openshift.io_mustgathers.yaml
+++ b/deploy/crds/managed.openshift.io_mustgathers.yaml
@@ -35,6 +35,11 @@ spec:
           spec:
             description: MustGatherSpec defines the desired state of MustGather
             properties:
+              audit:
+                default: false
+                description: A flag to specify if audit logs must be collected See
+                  documentation for further information.
+                type: boolean
               caseID:
                 description: The is of the case this must gather will be uploaded
                   to


### PR DESCRIPTION
Added a new field **audit** in the must-gather CRD, that when set to **true**, it uses the `gather_audit_logs` binary which exists already in the must-gather image.

```apiVersion: managed.openshift.io/v1alpha1
kind: MustGather
metadata:
  name: example-mustgather-full
spec:
  caseID: '02527285'
  caseManagementAccountSecretRef:
    name: case-management-creds
  serviceAccountRef:
    name: must-gather-admin
  audit: true 
```