### PR TITLE
SDCICD-1178: remove unknown fields from schema

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -45,18 +45,6 @@ objects:
         namespace: openshift-${REPO_NAME}
       spec:
         image: ${REGISTRY_IMG}@${IMAGE_DIGEST}
-        affinity:
-          nodeAffinity:
-            preferredDuringSchedulingIgnoredDuringExecution:
-            - preference:
-                matchExpressions:
-                - key: node-role.kubernetes.io/infra
-                  operator: Exists
-              weight: 1
-        tolerations:
-          - effect: NoSchedule
-            key: node-role.kubernetes.io/infra
-            operator: Exists
         displayName: ${REPO_NAME}
         icon:
           base64data: ''


### PR DESCRIPTION
the CatalogSource spec does not define `affinity` or `tolerations` at
the `spec` level. That is already set in the `grpcPodConfig`

https://issues.redhat.com/browse/SDCICD-1178

https://docs.openshift.com/container-platform/4.14/rest_api/operatorhub_apis/catalogsource-operators-coreos-com-v1alpha1.html

/cleanup

Signed-off-by: Brady Pratt <bpratt@redhat.com>
