### PR TITLE
SDCICD-1286: set resourceApplyMode to Upsert

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -27,7 +27,7 @@ objects:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
-    resourceApplyMode: Sync
+    resourceApplyMode: Upsert
     resources:
     - apiVersion: v1
       kind: Namespace


### PR DESCRIPTION
as a part of the on-going release versioning effort, adjust the behavior of the SelectorSyncSet to allow PKO to adopt the resources on a cluster and not be overwritten by Hive syncing.

Once Hive applies the resources, it will no longer try to resync the changes continuously which will allow Package Operator to take ownership of the resources and manage their lifecycle.

https://issues.redhat.com/browse/SDCICD-1286

https://docs.google.com/document/d/1cdJuVFk5OhSR6ceLKyBgSZjfPmsnWFeqab_EJUbI0t4/edit#heading=h.bi1qeu8b4rop