### PR TITLE
Revert "SDCICD-1286: set resourceApplyMode to Upsert"

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -27,7 +27,7 @@ objects:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
-    resourceApplyMode: Upsert
+    resourceApplyMode: Sync
     resources:
     - apiVersion: v1
       kind: Namespace


### PR DESCRIPTION
This reverts commit 061ec15939c8b39c3b0e9193abe7d3ad81c7fb77.

this change shouldn't have been promoted to prod as per https://redhat-internal.slack.com/archives/CFJD1NZFT/p1714371443733169

will revert this again after the changes have been promoted to prod