### PR TITLE
hack/olm-registry: sync NS labels from MCC

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -33,7 +33,10 @@ objects:
       kind: Namespace
       metadata:
         name: openshift-must-gather-operator
+        annotations:
+          openshift.io/node-selector: ""
         labels:
+          openshift.io/cluster-logging: "true"
           openshift.io/cluster-monitoring: 'true'
     - apiVersion: operators.coreos.com/v1alpha1
       kind: CatalogSource


### PR DESCRIPTION
this namespace resource exists (and is planned on being removed) in MCC and differs from this resource slightly. Sync the annotations and labels from that resource.

https://issues.redhat.com/browse/SDCICD-1292

https://github.com/openshift/managed-cluster-config/blob/adfaa3e71a3cc20e2ab444f0359e188ee6fb467c/deploy/osd-must-gather-operator/01-openshift-must-gather-operator.Namespace.yaml#L5-L9