### PR TITLE
Add missing envars to upload container

### DIFF
--- a/controllers/mustgather/template.go
+++ b/controllers/mustgather/template.go
@@ -19,19 +19,21 @@ const (
 
 	gatherCommandBinaryAudit   = "gather_audit_logs"
 	gatherCommandBinaryNoAudit = "gather"
-	gatherCommand              = "\ntimeout %v bash -x -c -- '/usr/bin/%v'\n\nstatus=$?\nif [[ $status -eq 124 || $status -eq 137 ]]; then\n  echo \"Gather timed out.\"\n  exit 0\nfi"
+	gatherCommand              = "timeout %v bash -x -c -- '/usr/bin/%v'\n\nstatus=$?\nif [[ $status -eq 124 || $status -eq 137 ]]; then\n  echo \"Gather timed out.\"\n  exit 0\nfi"
 	mustGatherImage            = "quay.io/openshift/origin-must-gather"
 	gatherContainerName        = "gather"
 
-	uploadContainerName   = "upload"
-	uploadEnvUsername     = "username"
-	uploadEnvPassword     = "password"
-	uploadEnvCaseId       = "caseid"
-	uploadEnvInternalUser = "internal_user"
-	uploadEnvHttpProxy    = "http_proxy"
-	uploadEnvHttpsProxy   = "https_proxy"
-	uploadEnvNoProxy      = "no_proxy"
-	uploadCommand         = "count=0\nuntil [ $count -gt 4 ]\ndo\n  while `pgrep -a gather > /dev/null`\n  do\n    echo \"waiting for gathers to complete ...\" \n    sleep 120\n    count=0\n  done\n  echo \"no gather is running ($count / 4)\"\n  ((count++))\n  sleep 30\ndone\n/usr/local/bin/upload\n"
+	uploadContainerName       = "upload"
+	uploadEnvUsername         = "username"
+	uploadEnvPassword         = "password"
+	uploadEnvCaseId           = "caseid"
+	uploadEnvInternalUser     = "internal_user"
+	uploadEnvHttpProxy        = "http_proxy"
+	uploadEnvHttpsProxy       = "https_proxy"
+	uploadEnvNoProxy          = "no_proxy"
+	uploadEnvMustGatherOutput = "must_gather_output"
+	uploadEnvMustGatherUpload = "must_gather_upload"
+	uploadCommand             = "count=0\nuntil [ $count -gt 4 ]\ndo\n  while `pgrep -a gather > /dev/null`\n  do\n    echo \"waiting for gathers to complete ...\"\n    sleep 120\n    count=0\n  done\n  echo \"no gather is running ($count / 4)\"\n  ((count++))\n  sleep 30\ndone\n/usr/local/bin/upload"
 )
 
 func getJobTemplate(operatorImage string, clusterVersion string, mustGather v1alpha1.MustGather) *batchv1.Job {
@@ -179,6 +181,14 @@ func getUploadContainer(
 			{
 				Name:  uploadEnvCaseId,
 				Value: caseId,
+			},
+			{
+				Name:  uploadEnvMustGatherOutput,
+				Value: volumeMountPath,
+			},
+			{
+				Name:  uploadEnvMustGatherUpload,
+				Value: volumeUploadMountPath,
 			},
 			{
 				Name:  uploadEnvInternalUser,

--- a/controllers/mustgather/template_test.go
+++ b/controllers/mustgather/template_test.go
@@ -71,7 +71,7 @@ func Test_getGatherContainer(t *testing.T) {
 				testFailed = true
 			}
 
-			if !strings.HasPrefix(containerCommand, fmt.Sprintf("\ntimeout %v", tt.timeout)) {
+			if !strings.HasPrefix(containerCommand, fmt.Sprintf("timeout %v", tt.timeout)) {
 				t.Logf("the duration was not properly added to the container command, got %v but wanted %v", strings.Split(containerCommand, " ")[1], tt.timeout.String())
 				testFailed = true
 			}


### PR DESCRIPTION
These envars were missed during the refactor in https://github.com/openshift/must-gather-operator/pull/138 , and were recently discovered when checking for parity between the old job CRs created by MGO and the new job CRs.

Also some minor updates to the formatting of strings. In particular, the upload container's command went from this:
```
        - command:
            - /bin/bash
            - -c
            - "count=0\nuntil [ $count -gt 4 ]\ndo\n  while `pgrep -a gather > /dev/null`\n
          \ do\n    echo \"waiting for gathers to complete ...\" \n    sleep 120\n
          \   count=0\n  done\n  echo \"no gather is running ($count / 4)\"\n  ((count++))\n
          \ sleep 30\ndone\n/usr/local/bin/upload\n"
```

To this:
```
        - command:
            - /bin/bash
            - -c
            - |-
              count=0
              until [ $count -gt 4 ]
              do
                while `pgrep -a gather > /dev/null`
                do
                  echo "waiting for gathers to complete ..."
                  sleep 120
                  count=0
                done
                echo "no gather is running ($count / 4)"
                ((count++))
                sleep 30
              done
              /usr/local/bin/upload
```

Both are identical, but the latter is much easier to read and understand.