### PR TITLE
[SDCICD-1286] Set SSS mode to Upsert as prep for RVMO adoption

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -1,3 +1,6 @@
+# !!! DO NOT EDIT !!!
+# This SSS is being removed and its contents migrated to the Release Bundle.
+# Please join #wg-rvmo if you have any questions or need to edit this file.
 apiVersion: v1
 kind: Template
 parameters:
@@ -27,7 +30,7 @@ objects:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
-    resourceApplyMode: Sync
+    resourceApplyMode: Upsert
     resources:
     - apiVersion: v1
       kind: Namespace


### PR DESCRIPTION
Must Gather Operator is the first operator being switched from being deployed directly to hives using its own SelectorSyncSet to being deployed as part of the release bundle ([managed-release-bundle-osd.git](https://github.com/openshift/managed-release-bundle-osd), [SDE-3672](https://issues.redhat.com//browse/SDE-3672)).

First step is to switch the current SelectorSyncSet to `Upsert` mode, which will allow deleting the SelectorSyncSet entirely without Hives messing up any MGO deployments on clusters.