### PR TITLE
Workaround for insufficient release branch detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 FIPS_ENABLED=true
 RELEASE_BRANCHED_BUILDS?=true
 
+# This needs to be hardcoded until https://issues.redhat.com/browse/SDCICD-1336 is fixed
+RELEASE_BRANCH=release-4.16
+
 include boilerplate/generated-includes.mk
 
 .PHONY: boilerplate-update


### PR DESCRIPTION
Should fix Jenkins builds until https://issues.redhat.com/browse/SDCICD-1336 is done.