### PR TITLE
Fix operator build when setting up sshpass

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -22,10 +22,7 @@ ENV OPERATOR=/usr/local/bin/must-gather-operator \
     USER_UID=1001 \
     USER_NAME=must-gather-operator
 
-RUN microdnf install tar gzip openssh-clients wget shadow-utils procps && \
-    wget https://kojipkgs.fedoraproject.org/packages/sshpass/1.06/9.el8/x86_64/sshpass-1.06-9.el8.x86_64.rpm && \
-    rpm -U sshpass-1.06-9.el8.x86_64.rpm && \
-    rm -f sshpass-1.06-9.el8.x86_64.rpm && \
+RUN microdnf install tar gzip openssh-clients wget shadow-utils procps sshpass && \
     microdnf clean all
 
 COPY --from=builder /src/build/_output/bin/${OPERATOR_BIN} /usr/local/bin/${OPERATOR_BIN}


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/OSD-24888 where MGO image builds are currently failing with error 
`error: Failed dependencies:
        libc.so.6(GLIBC_2.15)(64bit) is needed by sshpass-1.06-9.el8.x86_64
        libc.so.6(GLIBC_2.2.5)(64bit) is needed by sshpass-1.06-9.el8.x86_64
        libc.so.6(GLIBC_2.3.4)(64bit) is needed by sshpass-1.06-9.el8.x86_64
        libc.so.6(GLIBC_2.4)(64bit) is needed by sshpass-1.06-9.el8.x86_64
Error: building at STEP "RUN microdnf install tar gzip openssh-clients wget shadow-utils procps &&     wget https://kojipkgs.fedoraproject.org/packages/sshpass/1.06/9.el8/x86_64/sshpass-1.06-9.el8.x86_64.rpm &&     rpm -U sshpass-1.06-9.el8.x86_64.rpm &&     rm -f sshpass-1.06-9.el8.x86_64.rpm &&     microdnf clean all": while running runtime: exit status 1`


