### PR TITLE
Generate OLM bundles that SkipRange everything

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -6,4 +6,7 @@ const (
 
 	// OperatorNamespace
 	OperatorNamespace string = "openshift-must-gather-operator"
+
+	// MGO is being distributed as part of RVMO now, so use skiprange
+	EnableOLMSkipRange string = "true"
 )


### PR DESCRIPTION
With RVMO, the deployment pipeline is in control of the operator upgrades and we don't want OLM to try to be smart about it and try to think too much about which operator version can upgrade from which other version. We need it to just upgrade directly from whatever version is on the cluster to the newly-deployed version, no questions asked.

And that's what skiprange does. Instead of having all the previous versions listed explicitly in the OLM metadata, something like this is all that's going to in there:

```
    "name": "stable",
    "package": "osd-example-operator",
    "entries": [
        {
            "name": "osd-example-operator.v4.16.193-633c3df",
            "skipRange": ">=0.0.1 <4.16.193-633c3df"
        }
    ]
```

which is equivalent to "you can upgrade to me directly from any version".