### PR TITLE
Make sure PKO can always take over Hive objects

### DIFF
--- a/hack/release-bundle/resources.yaml.gotmpl
+++ b/hack/release-bundle/resources.yaml.gotmpl
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   name: openshift-${OPERATOR_NAME}
   annotations:
+    package-operator.run/collision-protection: IfNoController
     package-operator.run/phase: namespaces
     openshift.io/node-selector: ""
   labels:
@@ -15,6 +16,7 @@ metadata:
   name: ${OPERATOR_NAME}-registry
   namespace: openshift-${OPERATOR_NAME}
   annotations:
+    package-operator.run/collision-protection: IfNoController
     package-operator.run/phase: ${OPERATOR_NAME}
   labels:
     opsrc-datastore: "true"
@@ -42,6 +44,7 @@ metadata:
   name: ${OPERATOR_NAME}
   namespace: openshift-${OPERATOR_NAME}
   annotations:
+    package-operator.run/collision-protection: IfNoController
     package-operator.run/phase: ${OPERATOR_NAME}
 spec:
   channel: ${CHANNEL}
@@ -55,6 +58,7 @@ metadata:
   name: ${OPERATOR_NAME}
   namespace: openshift-${OPERATOR_NAME}
   annotations:
+    package-operator.run/collision-protection: IfNoController
     package-operator.run/phase: ${OPERATOR_NAME}
     olm.operatorframework.io/exclude-global-namespace-resolution: 'true'
 spec:


### PR DESCRIPTION
In case there's a long Hive sync pause at the wrong moment for a cluster, it could be possible for the release bundle to not be able to then take over MGO objects. Let's make sure that's never possible by setting what is basically "let PKO take over the object ownership" setting permanently for all objects that were previously owned by Hive.

This setting has already been present temporarily during the "release bundle takeover of MGO" phase ([see](https://github.com/openshift/managed-release-bundle-osd/pull/156/files#diff-2be9963f7f06e8d851fb8897f94082e40daa415ee9bfdeb273b1b7f8c7c65870L5)), but then I dropped it. And in hindsight that was a mistake, so I'm reinstating it.