### PR TITLE
Add mmazur as an owner until branching PR automation is finished

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,6 +8,7 @@ approvers:
 - bng0y
 - devppratik
 - dustman9000
+- mmazur
 - srep-functional-leads
 maintainers:
 - bng0y


### PR DESCRIPTION
With MGO being part of RVMO now, each change potentially means 6 PRs needing 6 lgtms.

This is going to be eventually solved with proper automation, but until it does, I'd prefer not to have bother people so much, while I make RVMO-related adjustments to MGO.