### PR TITLE
osde2e: mark upgrade test as pending

### DIFF
--- a/osde2e/must_gather_operator_tests.go
+++ b/osde2e/must_gather_operator_tests.go
@@ -106,7 +106,7 @@ var _ = ginkgo.Describe("must-gather-operator", ginkgo.Ordered, func() {
 		ginkgo.Entry("by openshift-backplane-cee", "test@redhat.com", "system:serviceaccounts:openshift-backplane-cee"),
 	)
 
-	ginkgo.It("can be upgraded", func(ctx context.Context) {
+	ginkgo.PIt("can be upgraded", func(ctx context.Context) {
 		ginkgo.By("forcing operator upgrade")
 		err := oc.UpgradeOperator(ctx, operator, namespace)
 		Expect(err).NotTo(HaveOccurred(), "operator upgrade failed")


### PR DESCRIPTION
now that this operator is migrated to RVMO, the old code that inspected the OLM bundle to find previous versions and upgrade from it no longer works. Disable the perm failing test