### PR TITLE
Dummy update to README.md to work around deploy error

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,4 @@ export DEFAULT_MUST_GATHER_IMAGE='quay.io/openshift/origin-must-gather:latest'
 export JOB_TEMPLATE_FILE_NAME=./build/templates/job.template.yaml
 OPERATOR_NAME=must-gather-operator operator-sdk run --verbose --local --namespace ''
 ```
+


### PR DESCRIPTION
The current release-4.17 branch has an all-numberic short Git commit
hash with a leading zero, which is triggering a failure condition for
the operator subscription when deployed:

```
    - message: 'failed to turn bundle into steps: Numeric PreRelease version must
        not contain leading zeroes "0416065"'
      reason: ErrorPreventedResolution
      status: "True"
      type: ResolutionFailed
```

This PR contains a newline to the README.md as a dummy commit to
generate a new hash.

[OSD-25523](https://issues.redhat.com/browse/OSD-25523) has been opened
to address this issue long term.

Signed-off-by: Chris Collins <collins.christopher@gmail.com>
