### PR TITLE
OSD-28575 added limits for MEM and CPU for must-gather-operator

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -16,7 +16,7 @@ COPY . /src
 
 RUN make go-build
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1179.1739286367
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1179.1741863533
 ENV OPERATOR=/usr/local/bin/must-gather-operator \
     OPERATOR_BIN=must-gather-operator \
     USER_UID=1001 \

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1179.1739286367
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1179.1741863533
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/deploy/99_must-gather-operator.Deployment.yaml
+++ b/deploy/99_must-gather-operator.Deployment.yaml
@@ -33,6 +33,10 @@ spec:
           command:
           - must-gather-operator
           imagePullPolicy: Always
+          resources:
+            limits:
+              memory: "1Gi"
+              cpu: "100m"
           env:
             - name: POD_NAME
               valueFrom:


### PR DESCRIPTION
Enforce CPU and MEM limits for the must gather Operator.

In order to choose the values I went into a long standing clusters to check over time how much MEM and CPU has been consuming. In addition I trigger a full must-must gather on the cluster in order to see possible spikes and consumption during the must gather. The operator itself consumes very low resources, since its only job is to read the presence of CR and deploy a Job on the cluster which will perform the gathering. The consumption of resources by this deployed must-gather pod and subsequent enforcement of limits will be done in another PR.