### PR TITLE
Update OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,15 +1,12 @@
 reviewers:
-- bng0y
-- devppratik
-- dustman9000
-- srep-functional-team-hulk
+- shivprakashmuley
+- swghosh
+- TrilokGeer
 approvers:
-- bng0y
-- devppratik
-- dustman9000
-- mmazur
-- srep-functional-leads
-- srep-team-leads
+- shivprakashmuley
+- swghosh
+- TrilokGeer
 maintainers:
-- bng0y
-- dustman9000
+- shivprakashmuley
+- swghosh
+- TrilokGeer

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -16,7 +16,7 @@ COPY . /src
 
 RUN make go-build
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1295.1749680713
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1753764099
 ENV OPERATOR=/usr/local/bin/must-gather-operator \
     OPERATOR_BIN=must-gather-operator \
     USER_UID=1001 \

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1295.1749680713
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1753764099
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe


### PR DESCRIPTION
Reflects ownership change as a result of OAP team recently taking over the ownership of the must-gather component.

As part of the [roadmap](https://issues.redhat.com/browse/OCPSTRAT-2259), must-gather operator will be productised as a Day 2 OLM-managed operator on the OpenShift catalog.