### PR TITLE
MG-46: Make ART-istic bundle

### DIFF
--- a/bundle/bundle.Dockerfile
+++ b/bundle/bundle.Dockerfile
@@ -1,0 +1,9 @@
+FROM scratch
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=must-gather-operator
+LABEL operators.operatorframework.io.bundle.channels.v1=tech-preview
+LABEL operators.operatorframework.io.bundle.channel.default.v1=tech-preview
+COPY manifests/tech-preview/*.yaml /manifests/
+COPY metadata/annotations.yaml /metadata/annotations.yaml 

--- a/bundle/manifests/art.yaml
+++ b/bundle/manifests/art.yaml
@@ -1,0 +1,15 @@
+updates:
+  - file: "tech-preview/must-gather-operator.clusterserviceversion.yaml" # relative to this file
+    update_list:
+    # replace metadata.name value
+    - search: "must-gather-operator.v{MAJOR}.{MINOR}.0"
+      replace: "must-gather-operator.v{FULL_VER}"
+    # replace entire version line, otherwise would replace 4.3.0 anywhere
+    - search: "version: {MAJOR}.{MINOR}.0"
+      replace: "version: {FULL_VER}"
+    - search: 'olm.skipRange: ">=4.20.0-0 <{MAJOR}.{MINOR}.0"'
+      replace: 'olm.skipRange: ">=4.20.0-0 <{FULL_VER}"'
+  - file: "must-gather-operator.package.yaml"
+    update_list:
+    - search: "currentCSV: must-gather-operator.v{MAJOR}.{MINOR}.0"
+      replace: "currentCSV: must-gather-operator.v{FULL_VER}" 

--- a/bundle/manifests/must-gather-operator.package.yaml
+++ b/bundle/manifests/must-gather-operator.package.yaml
@@ -1,0 +1,4 @@
+packageName: must-gather-operator
+channels:
+- name: tech-preview
+  currentCSV: must-gather-operator.v4.20.0 

--- a/bundle/manifests/tech-preview/image-references
+++ b/bundle/manifests/tech-preview/image-references
@@ -1,0 +1,13 @@
+---
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+spec:
+  tags:
+  - name: must-gather-operator
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-must-gather-operator:latest
+  - name: must-gather
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-must-gather:latest 

--- a/bundle/manifests/tech-preview/managed.openshift.io_mustgathers.yaml
+++ b/bundle/manifests/tech-preview/managed.openshift.io_mustgathers.yaml
@@ -1,0 +1,193 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: mustgathers.managed.openshift.io
+spec:
+  group: managed.openshift.io
+  names:
+    kind: MustGather
+    listKind: MustGatherList
+    plural: mustgathers
+    singular: mustgather
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MustGather is the Schema for the mustgathers API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MustGatherSpec defines the desired state of MustGather
+            properties:
+              audit:
+                default: false
+                description: |-
+                  A flag to specify if audit logs must be collected
+                  See documentation for further information.
+                type: boolean
+              caseID:
+                description: The is of the case this must gather will be uploaded
+                  to
+                type: string
+              caseManagementAccountSecretRef:
+                description: the secret container a username and password field to
+                  be used to authenticate with red hat case management systems
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              internalUser:
+                default: true
+                description: |-
+                  A flag to specify if the upload user provided in the caseManagementAccountSecret is a RH internal user.
+                  See documentation for further information.
+                type: boolean
+              mustGatherTimeout:
+                description: |-
+                  A time limit for gather command to complete a floating point number with a suffix:
+                  "s" for seconds, "m" for minutes, "h" for hours, or "d" for days.
+                  Will default to no time limit.
+                format: duration
+                type: string
+              proxyConfig:
+                description: This represents the proxy configuration to be used. If
+                  left empty it will default to the cluster-level proxy configuration.
+                properties:
+                  httpProxy:
+                    description: httpProxy is the URL of the proxy for HTTP requests.  Empty
+                      means unset and will not result in an env var.
+                    type: string
+                  httpsProxy:
+                    description: httpsProxy is the URL of the proxy for HTTPS requests.  Empty
+                      means unset and will not result in an env var.
+                    type: string
+                  noProxy:
+                    description: noProxy is the list of domains for which the proxy
+                      should not be used.  Empty means unset and will not result in
+                      an env var.
+                    type: string
+                type: object
+              serviceAccountRef:
+                description: |-
+                  the service account to use to run the must gather job pod, defaults to default
+                  +kubebuilder:default:="{Name:default}"
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - caseID
+            - caseManagementAccountSecretRef
+            type: object
+          status:
+            description: MustGatherStatus defines the observed state of MustGather
+            properties:
+              completed:
+                type: boolean
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastUpdate:
+                format: date-time
+                type: string
+              reason:
+                type: string
+              status:
+                type: string
+            required:
+            - completed
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/bundle/manifests/tech-preview/must-gather-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/tech-preview/must-gather-operator.clusterserviceversion.yaml
@@ -1,0 +1,227 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: must-gather-operator.v4.20.0
+  namespace: must-gather-operator
+  annotations:
+    categories: Monitoring, Application Runtime
+    operatorframework.io/suggested-namespace: must-gather-operator
+    capabilities: Full Lifecycle
+    description: Operator to enable CEE to collect must-gathers from OSDv4 clusters
+    containerImage: quay.io/openshift/origin-must-gather-operator:latest
+    createdAt: "2020-07-31T16:12:36Z"
+    support: Red Hat
+    repository: https://github.com/openshift/must-gather-operator
+    olm.skipRange: ">=4.20.0-0 <4.20.0"
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "true"
+    features.operators.openshift.io/proxy-aware: "true"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
+    features.operators.openshift.io/cnf: "false"
+    features.operators.openshift.io/cni: "false"
+    features.operators.openshift.io/csi: "true"
+  labels:
+    operator-metering: "true"
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.s390x: supported
+    operatorframework.io/os.linux: supported
+spec:
+  displayName: Must Gather Operator
+  description: |
+    The Must Gather Operator helps collecting must-gather diagnostic information from OpenShift clusters.
+    
+    ## About Must Gather Operator
+    
+    The Must Gather Operator enables Customer Experience and Engagement (CEE) teams to collect diagnostic 
+    information (must-gathers) from OpenShift Dedicated v4 clusters. This operator provides a custom 
+    resource definition (CRD) that allows authorized users to create must-gather jobs in a controlled manner.
+    
+    ## Features
+    
+    * Automated must-gather collection
+    * Support for different must-gather images
+    * Configurable resource limits
+    * Secure collection and storage
+  icon:
+    - base64data: PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxOTIgMTQ1Ij48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UwMDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlJlZEhhdC1Mb2dvLUhhdC1Db2xvcjwvdGl0bGU+PHBhdGggZD0iTTE1Ny43Nyw2Mi42MWExNCwxNCwwLDAsMSwuMzEsMy40MmMwLDE0Ljg4LTE4LjEsMTcuNDYtMzAuNjEsMTcuNDZDNzguODMsODMuNDksNDIuNTMsNTMuMjYsNDIuNTMsNDRhNi40Myw2LjQzLDAsMCwxLC4yMi0xLjk0bC0zLjY2LDkuMDZhMTguNDUsMTguNDUsMCwwLDAtMS41MSw3LjMzYzAsMTguMTEsNDEsNDUuNDgsODcuNzQsNDUuNDgsMjAuNjksMCwzNi40My03Ljc2LDM2LjQzLTIxLjc3LDAtMS4wOCwwLTEuOTQtMS43My0xMC4xM1oiLz48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik0xMjcuNDcsODMuNDljMTIuNTEsMCwzMC42MS0yLjU4LDMwLjYxLTE3LjQ2YTE0LDE0LDAsMCwwLS4zMS0zLjQybC03LjQ1LTMyLjM2Yy0xLjcyLTcuMTItMy4yMy0xMC4zNS0xNS43My0xNi42QzEyNC44OSw4LjY5LDEwMy43Ni41LDk3LjUxLjUsOTEuNjkuNSw5MCw4LDgzLjA2LDhjLTYuNjgsMC0xMS42NC01LjYtMTcuODktNS42LTYsMC05LjkxLDQuMDktMTIuOTMsMTIuNSwwLDAtOC40MSwyMy43Mi05LjQ5LDI3LjE2QTYuNDMsNi40MywwLDAsMCw0Mi41Myw0NGMwLDkuMjIsMzYuMywzOS40NSw4NC45NCwzOS40NU0xNjAsNzIuMDdjMS43Myw4LjE5LDEuNzMsOS4wNSwxLjczLDEwLjEzLDAsMTQtMTUuNzQsMjEuNzctMzYuNDMsMjEuNzdDNzguNTQsMTA0LDM3LjU4LDc2LjYsMzcuNTgsNTguNDlhMTguNDUsMTguNDUsMCwwLDEsMS41MS03LjMzQzIyLjI3LDUyLC41LDU1LC41LDc0LjIyYzAsMzEuNDgsNzQuNTksNzAuMjgsMTMzLjY1LDcwLjI4LDQ1LjI4LDAsNTYuNy0yMC40OCw1Ni43LTM2LjY1LDAtMTIuNzItMTEtMjcuMTYtMzAuODMtMzUuNzgiLz48L3N2Zz4=
+      mediatype: image/svg+xml
+  keywords:
+  - kubernetes
+  - openshift
+  - monitoring
+  - diagnostics
+  - must-gather
+  - support
+  links:
+    - name: Documentation
+      url: https://github.com/openshift/must-gather-operator
+    - name: Source Repository
+      url: https://github.com/openshift/must-gather-operator
+  version: 4.20.0
+  maturity: tech-preview
+  maintainers:
+    - email: aos-staff@redhat.com
+      name: Red Hat
+  minKubeVersion: 1.26.0
+  provider:
+    name: Red Hat, Inc
+  installModes:
+  - type: OwnNamespace
+    supported: false
+  - type: SingleNamespace
+    supported: false
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: true
+  install:
+    strategy: deployment
+    spec:
+      clusterPermissions:
+      - serviceAccountName: must-gather-operator
+        rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - services/finalizers
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - apps
+          resourceNames:
+          - must-gather-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+        - apiGroups:
+          - apps
+          resources:
+          - replicasets
+          - deployments
+          verbs:
+          - get
+        - apiGroups:
+          - managed.openshift.io
+          resources:
+          - mustgathers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - managed.openshift.io
+          resources:
+          - mustgathers/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - batch
+          resources:
+          - jobs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+      deployments:
+      - name: must-gather-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: must-gather-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: must-gather-operator
+            spec:
+              containers:
+              - command:
+                - must-gather-operator
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: must-gather-operator
+                image: quay.io/openshift/origin-must-gather-operator:latest
+                imagePullPolicy: Always
+                name: must-gather-operator
+                resources:
+                  limits:
+                    cpu: 200m
+                    memory: 512Mi
+                  requests:
+                    cpu: 100m
+                    memory: 256Mi
+              serviceAccountName: must-gather-operator
+  customresourcedefinitions:
+    owned:
+    - displayName: Must Gather
+      group: managed.openshift.io
+      kind: MustGather
+      name: mustgathers.managed.openshift.io
+      description: Represents a must-gather diagnostic collection job
+      version: v1alpha1

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -1,0 +1,7 @@
+annotations:
+  operators.operatorframework.io.bundle.channel.default.v1: tech-preview
+  operators.operatorframework.io.bundle.channels.v1: tech-preview
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: must-gather-operator 


### PR DESCRIPTION
Follow-up over https://github.com/openshift-eng/ocp-build-data/pull/7302

Update and add `bundle/` directory to make ClusterServiceVersion and bundle build ART-istic (ready to be built and delivered by OpenShift Automated Release Tooling).

TODO(in follow-up)
- [ ] Add a make target to populate/update the CRD in the bundle dir.