### PR TITLE
MG-45: Add `-y` to microdnf in Dockerfile

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -22,7 +22,7 @@ ENV OPERATOR=/usr/local/bin/must-gather-operator \
     USER_UID=1001 \
     USER_NAME=must-gather-operator
 
-RUN microdnf install tar gzip openssh-clients wget shadow-utils procps sshpass && \
+RUN microdnf install -y tar gzip openssh-clients wget shadow-utils procps sshpass && \
     microdnf clean all
 
 COPY --from=builder /src/build/_output/bin/${OPERATOR_BIN} /usr/local/bin/${OPERATOR_BIN}


### PR DESCRIPTION
For `registry.ci.openshift.org/ocp/ubi-minimal:9` base image to be used in building the operator image,
the `microdnf -y` is required else the build get stalled waiting for a user input.