### PR TITLE
MG-46: Fix `origin-must-gather` ImageStream name in `bundle/` dir

### DIFF
--- a/bundle/manifests/tech-preview/image-references
+++ b/bundle/manifests/tech-preview/image-references
@@ -7,7 +7,7 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-must-gather-operator:latest
-  - name: must-gather
+  - name: must-gather-rhel9
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-must-gather:latest 


### PR DESCRIPTION
Fixes the `ImageStream` name in image-references, required for ART's bundle build pipeline.

Plausible fix for https://groups.google.com/a/redhat.com/g/openshift-oap-tech-team/c/zn8I9e1xsZg/m/GICYJ4KXAQAJ.