### PR TITLE
MG-41: Added support to fetch cluster wide proxy config

### DIFF
--- a/api/v1alpha1/mustgather_types.go
+++ b/api/v1alpha1/mustgather_types.go
@@ -17,8 +17,8 @@ limitations under the License.
 package v1alpha1
 
 import (
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
@@ -63,13 +63,13 @@ type MustGatherSpec struct {
 
 // +k8s:openapi-gen=true
 type ProxySpec struct {
-	// httpProxy is the URL of the proxy for HTTP requests.  Empty means unset and will not result in an env var.
-	// +optional
-	HTTPProxy string `json:"httpProxy,omitempty"`
+	// httpProxy is the URL of the proxy for HTTP requests.
+	// +kubebuilder:validation:Required
+	HTTPProxy string `json:"httpProxy"`
 
-	// httpsProxy is the URL of the proxy for HTTPS requests.  Empty means unset and will not result in an env var.
-	// +optional
-	HTTPSProxy string `json:"httpsProxy,omitempty"`
+	// httpsProxy is the URL of the proxy for HTTPS requests.
+	// +kubebuilder:validation:Required
+	HTTPSProxy string `json:"httpsProxy"`
 
 	// noProxy is the list of domains for which the proxy should not be used.  Empty means unset and will not result in an env var.
 	// +optional

--- a/controllers/mustgather/template.go
+++ b/controllers/mustgather/template.go
@@ -52,26 +52,20 @@ func getJobTemplate(operatorImage string, clusterVersion string, mustGather v1al
 		httpProxy = mustGather.Spec.ProxyConfig.HTTPProxy
 		httpsProxy = mustGather.Spec.ProxyConfig.HTTPSProxy
 		noProxy = mustGather.Spec.ProxyConfig.NoProxy
-	} else {
-		// Fallback to operator's environment proxy variables
+	}
+
+	// Fallback to operator's environment proxy variables only if not provided in the CR
+	if httpProxy == "" && httpsProxy == "" {
 		envVars := proxy.ReadProxyVarsFromEnv()
-		if len(envVars) > 0 {
-			// Extract proxy values from the environment variables slice
-			for _, envVar := range envVars {
-				switch envVar.Name {
-				case "HTTP_PROXY":
-					if httpProxy == "" {
-						httpProxy = envVar.Value
-					}
-				case "HTTPS_PROXY":
-					if httpsProxy == "" {
-						httpsProxy = envVar.Value
-					}
-				case "NO_PROXY":
-					if noProxy == "" {
-						noProxy = envVar.Value
-					}
-				}
+		// the below loop should implicitly handle len(envVars) > 0
+		for _, envVar := range envVars {
+			switch envVar.Name {
+			case "HTTP_PROXY":
+				httpProxy = envVar.Value
+			case "HTTPS_PROXY":
+				httpsProxy = envVar.Value
+			case "NO_PROXY":
+				noProxy = envVar.Value
 			}
 		}
 	}

--- a/controllers/mustgather/template.go
+++ b/controllers/mustgather/template.go
@@ -6,10 +6,11 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"github.com/operator-framework/operator-lib/proxy"
 	"strconv"
 	"time"
 )
+
+import "github.com/operator-framework/operator-lib/proxy"
 
 const (
 	infraNodeLabelKey     = "node-role.kubernetes.io/infra"
@@ -37,7 +38,7 @@ const (
 	uploadCommand             = "count=0\nuntil [ $count -gt 4 ]\ndo\n  while `pgrep -a gather > /dev/null`\n  do\n    echo \"waiting for gathers to complete ...\"\n    sleep 120\n    count=0\n  done\n  echo \"no gather is running ($count / 4)\"\n  ((count++))\n  sleep 30\ndone\n/usr/local/bin/upload"
 
 	// SSH directory and known hosts file
-	sshDir       = "/tmp/must-gather-operator/.ssh"
+	sshDir         = "/tmp/must-gather-operator/.ssh"
 	knownHostsFile = "/tmp/must-gather-operator/.ssh/known_hosts"
 )
 

--- a/deploy/crds/managed.openshift.io_mustgathers.yaml
+++ b/deploy/crds/managed.openshift.io_mustgathers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.18.1-0.20250818134112-b624019bbe8d
   name: mustgathers.managed.openshift.io
 spec:
   group: managed.openshift.io
@@ -82,18 +82,19 @@ spec:
                   left empty it will default to the cluster-level proxy configuration.
                 properties:
                   httpProxy:
-                    description: httpProxy is the URL of the proxy for HTTP requests.  Empty
-                      means unset and will not result in an env var.
+                    description: httpProxy is the URL of the proxy for HTTP requests.
                     type: string
                   httpsProxy:
-                    description: httpsProxy is the URL of the proxy for HTTPS requests.  Empty
-                      means unset and will not result in an env var.
+                    description: httpsProxy is the URL of the proxy for HTTPS requests.
                     type: string
                   noProxy:
                     description: noProxy is the list of domains for which the proxy
                       should not be used.  Empty means unset and will not result in
                       an env var.
                     type: string
+                required:
+                - httpProxy
+                - httpsProxy
                 type: object
               serviceAccountRef:
                 description: |-

--- a/vendor/github.com/operator-framework/operator-lib/proxy/doc.go
+++ b/vendor/github.com/operator-framework/operator-lib/proxy/doc.go
@@ -1,0 +1,33 @@
+// Copyright 2021 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+Package proxy implements helper functions to facilitate making operators proxy-aware.
+
+This package assumes that proxy environment variables `HTTPS_PROXY`,
+`HTTP_PROXY`, and/or `NO_PROXY` are set in the Operator environment, typically
+via the Operator deployment.
+
+Proxy-aware operators can use the ReadProxyVarsFromEnv to retrieve these values
+as a slice of corev1 EnvVars. Each of the proxy variables are duplicated in
+upper and lower case to support applications that use either. In their
+reconcile functions, Operator authors are then responsible for setting these
+variables in the Container Envs that must use the proxy, For example:
+
+	// Pods with Kubernetes < 1.22
+	for i, cSpec := range (myPod.Spec.Containers) {
+		myPod.Spec.Containers[i].Env = append(cSpec.Env, ReadProxyVarsFromEnv()...)
+	}
+*/
+package proxy

--- a/vendor/github.com/operator-framework/operator-lib/proxy/proxy.go
+++ b/vendor/github.com/operator-framework/operator-lib/proxy/proxy.go
@@ -1,0 +1,45 @@
+// Copyright 2021 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"os"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// ProxyEnvNames are standard environment variables for proxies
+var ProxyEnvNames = []string{"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"}
+
+// ReadProxyVarsFromEnv retrieves the standard proxy-related environment
+// variables from the running environment and returns a slice of corev1 EnvVar
+// containing upper and lower case versions of those variables.
+func ReadProxyVarsFromEnv() []corev1.EnvVar {
+	envVars := []corev1.EnvVar{}
+	for _, s := range ProxyEnvNames {
+		value, isSet := os.LookupEnv(s)
+		if isSet {
+			envVars = append(envVars, corev1.EnvVar{
+				Name:  s,
+				Value: value,
+			}, corev1.EnvVar{
+				Name:  strings.ToLower(s),
+				Value: value,
+			})
+		}
+	}
+	return envVars
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -261,6 +261,7 @@ github.com/openshift/osde2e-common/pkg/gomega/matchers
 ## explicit; go 1.17
 github.com/operator-framework/operator-lib/internal/utils
 github.com/operator-framework/operator-lib/leader
+github.com/operator-framework/operator-lib/proxy
 # github.com/pkg/errors v0.9.1
 ## explicit
 github.com/pkg/errors


### PR DESCRIPTION
This PR addresses https://issues.redhat.com/browse/MG-41.

This PR fetches proxy config through ENV vars that are set in must-gather-operator deployment by OLM on a proxy setup. This is needed when proxyConfig is not input by user (in must-gather custom resource) on a proxy environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Must-gather jobs now honor proxy settings from the custom resource and fall back to operator environment variables when appropriate.

* Breaking Changes
  * proxyConfig.httpProxy and proxyConfig.httpsProxy are now required in the CRD.

* Documentation
  * Simplified CRD descriptions for proxy fields.
  * Added package documentation for proxy helpers.

* Tests
  * Added unit tests validating proxy precedence and fallback behavior.

* Chores
  * Vendored operator proxy helpers and updated module metadata; serviceAccountRef default set to "default".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->