### PR TITLE
MG-56: Flag based deletion of must-gather job and CR

### DIFF
--- a/api/v1alpha1/mustgather_types.go
+++ b/api/v1alpha1/mustgather_types.go
@@ -51,6 +51,11 @@ type MustGatherSpec struct {
 	// If not specified, the bundle will not be uploaded.
 	// +kubebuilder:validation:Optional
 	UploadTarget *UploadTargetSpec `json:"uploadTarget,omitempty"`
+
+	// A flag to specify if resources (secret, job, pods) should be retained when the MustGather completes.
+	// If set to true, resources will be retained. If false or not set, resources will be deleted (default behavior).
+	// +kubebuilder:default:=false
+	RetainResourcesOnCompletion bool `json:"retainResourcesOnCompletion,omitempty"`
 }
 
 // SFTPSpec defines the desired state of SFTPSpec

--- a/bundle/manifests/tech-preview/operator.openshift.io_mustgathers.yaml
+++ b/bundle/manifests/tech-preview/operator.openshift.io_mustgathers.yaml
@@ -71,6 +71,12 @@ spec:
                 - httpProxy
                 - httpsProxy
                 type: object
+              retainResourcesOnCompletion:
+                default: false
+                description: |-
+                  A flag to specify if resources (secret, job, pods) should be retained when the MustGather completes.
+                  If set to true, resources will be retained. If false or not set, resources will be deleted (default behavior).
+                type: boolean
               serviceAccountRef:
                 description: |-
                   the service account to use to run the must gather job pod, defaults to default

--- a/controllers/mustgather/mustgather_controller.go
+++ b/controllers/mustgather/mustgather_controller.go
@@ -375,6 +375,7 @@ func remove(list []string, s string) []string {
 // cleanupMustGatherResources cleans up the secret, job, and pods associated with a MustGather instance
 func (r *MustGatherReconciler) cleanupMustGatherResources(ctx context.Context, reqLogger logr.Logger, instance *mustgatherv1alpha1.MustGather, operatorNs string) error {
 	reqLogger.Info("cleaning up resources")
+	var err error
 
 	// delete secret in the operator namespace
 	if instance.Spec.UploadTarget != nil && instance.Spec.UploadTarget.SFTP != nil && instance.Spec.UploadTarget.SFTP.CaseManagementAccountSecretRef.Name != "" {
@@ -386,7 +387,7 @@ func (r *MustGatherReconciler) cleanupMustGatherResources(ctx context.Context, r
 			},
 		}
 
-		err := r.DeleteResourceIfExists(ctx, tmpSecret)
+		err = r.DeleteResourceIfExists(ctx, tmpSecret)
 
 		if err != nil {
 			reqLogger.Error(err, fmt.Sprintf("failed to delete %s secret", tmpSecretName))

--- a/controllers/mustgather/mustgather_controller.go
+++ b/controllers/mustgather/mustgather_controller.go
@@ -32,6 +32,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -85,7 +86,7 @@ func (r *MustGatherReconciler) Reconcile(ctx context.Context, request reconcile.
 
 	// Fetch the MustGather instance
 	instance := &mustgatherv1alpha1.MustGather{}
-	err := r.GetClient().Get(context.TODO(), request.NamespacedName, instance)
+	err := r.GetClient().Get(ctx, request.NamespacedName, instance)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
@@ -97,11 +98,11 @@ func (r *MustGatherReconciler) Reconcile(ctx context.Context, request reconcile.
 		return reconcile.Result{}, err
 	}
 
-	if !r.IsInitialized(instance) {
-		err := r.GetClient().Update(context.TODO(), instance)
+	if !r.IsInitialized(ctx, instance) {
+		err := r.GetClient().Update(ctx, instance)
 		if err != nil {
 			log.Error(err, "unable to update instance", "instance", instance)
-			return r.ManageError(context.TODO(), instance, err)
+			return r.ManageError(ctx, instance, err)
 		}
 		return reconcile.Result{}, nil
 	}
@@ -117,71 +118,28 @@ func (r *MustGatherReconciler) Reconcile(ctx context.Context, request reconcile.
 	// indicated by the deletion timestamp being set.
 	isMustGatherMarkedToBeDeleted := instance.GetDeletionTimestamp() != nil
 	if isMustGatherMarkedToBeDeleted {
+		reqLogger.Info("mustgather instance is marked for deletion")
 		if contains(instance.GetFinalizers(), mustGatherFinalizer) {
 			// Run finalization logic for mustGatherFinalizer. If the
 			// finalization logic fails, don't remove the finalizer so
 			// that we can retry during the next reconciliation.
 
-			// delete secret in the operator namespace
-			if instance.Spec.UploadTarget != nil && instance.Spec.UploadTarget.SFTP != nil && instance.Spec.UploadTarget.SFTP.CaseManagementAccountSecretRef.Name != "" {
-				tmpSecretName := instance.Spec.UploadTarget.SFTP.CaseManagementAccountSecretRef.Name
-				tmpSecret := &corev1.Secret{}
-				err = r.GetClient().Get(context.TODO(), types.NamespacedName{
-					Namespace: operatorNs,
-					Name:      tmpSecretName,
-				}, tmpSecret)
+			// Clean up resources if RetainResourcesOnCompletion is false (default behavior)
+			if !instance.Spec.RetainResourcesOnCompletion {
+				reqLogger.V(4).Info("running finalization logic for mustGatherFinalizer")
+				err := r.cleanupMustGatherResources(ctx, reqLogger, instance, operatorNs)
 				if err != nil {
-					reqLogger.Error(err, fmt.Sprintf("Failed to get %s secret", tmpSecretName))
-				} else {
-					err = r.GetClient().Delete(context.TODO(), tmpSecret)
-					if err != nil {
-						reqLogger.Error(err, fmt.Sprintf("Failed to delete %s secret", tmpSecretName))
-						return reconcile.Result{}, err
-					}
-				}
-			}
-
-			// delete job from operator namespace
-			tmpJob := &batchv1.Job{}
-			err = r.GetClient().Get(context.TODO(), types.NamespacedName{
-				Namespace: operatorNs,
-				Name:      instance.Name,
-			}, tmpJob)
-			if err != nil {
-				reqLogger.Error(err, fmt.Sprintf("Failed to get %s job", instance.Name))
-			} else {
-				// delete pods owned by job
-				podList := &corev1.PodList{}
-				listOpts := []client.ListOption{
-					client.InNamespace(operatorNs),
-					client.MatchingLabels{"controller-uid": string(tmpJob.UID)},
-				}
-				if err = r.GetClient().List(context.TODO(), podList, listOpts...); err != nil {
-					log.Error(err, "Failed to list pods", "Namespace", operatorNs, "UID", tmpJob.UID)
-				} else {
-					for _, tmpPod := range podList.Items {
-						tmpPod := tmpPod
-						err = r.GetClient().Delete(context.TODO(), &tmpPod)
-						if err != nil {
-							reqLogger.Error(err, fmt.Sprintf("Failed to delete %s pod", tmpPod.Name))
-							return reconcile.Result{}, err
-						}
-					}
-					// finally delete job
-					err = r.GetClient().Delete(context.TODO(), tmpJob)
-					if err != nil {
-						reqLogger.Error(err, fmt.Sprintf("Failed to delete %s job", tmpJob.Name))
-						return reconcile.Result{}, err
-					}
+					reqLogger.Error(err, "failed to cleanup MustGather resources during deletion")
+					return reconcile.Result{}, err
 				}
 			}
 
 			// Remove mustGatherFinalizer. Once all finalizers have been
 			// removed, the object will be deleted.
 			instance.SetFinalizers(remove(instance.GetFinalizers(), mustGatherFinalizer))
-			err := r.GetClient().Update(context.TODO(), instance)
+			err := r.GetClient().Update(ctx, instance)
 			if err != nil {
-				return r.ManageError(context.TODO(), instance, err)
+				return r.ManageError(ctx, instance, err)
 			}
 		}
 		return reconcile.Result{}, nil
@@ -189,100 +147,136 @@ func (r *MustGatherReconciler) Reconcile(ctx context.Context, request reconcile.
 
 	// Add finalizer for this CR
 	if !contains(instance.GetFinalizers(), mustGatherFinalizer) {
-		if err := r.addFinalizer(reqLogger, instance); err != nil {
+		if err := r.addFinalizer(ctx, reqLogger, instance); err != nil {
 			return reconcile.Result{}, err
 		}
 	}
 
-	job, err := r.getJobFromInstance(instance)
+	job, err := r.getJobFromInstance(ctx, instance)
 	if err != nil {
 		log.Error(err, "unable to get job from", "instance", instance)
-		return r.ManageError(context.TODO(), instance, err)
+		return r.ManageError(ctx, instance, err)
 	}
 
 	job1 := &batchv1.Job{}
-	err = r.GetClient().Get(context.TODO(), types.NamespacedName{
+	err = r.GetClient().Get(ctx, types.NamespacedName{
 		Name:      job.GetName(),
 		Namespace: job.GetNamespace(),
 	}, job1)
 
 	if err != nil {
-		if errors.IsNotFound(err) {
-			// look up user secret and copy it to operator namespace
-			if instance.Spec.UploadTarget != nil && instance.Spec.UploadTarget.SFTP != nil && instance.Spec.UploadTarget.SFTP.CaseManagementAccountSecretRef.Name != "" {
-				secretName := instance.Spec.UploadTarget.SFTP.CaseManagementAccountSecretRef.Name
-				userSecret := &corev1.Secret{}
-				err = r.GetClient().Get(context.TODO(), types.NamespacedName{
-					Namespace: instance.Namespace,
-					Name:      secretName,
-				}, userSecret)
-				if err != nil {
-					if errors.IsNotFound(err) {
-						log.Error(err, fmt.Sprintf("the secret %s was not found in namespace %s", secretName, instance.Namespace))
-						return reconcile.Result{}, nil
-					}
-					log.Error(err, fmt.Sprintf("Error getting secret (%s)", secretName))
-					return reconcile.Result{Requeue: true}, err
-				}
+		if !errors.IsNotFound(err) {
+			// Error reading the object - requeue the request.
+			log.Error(err, "unable to look up", "job", types.NamespacedName{
+				Name:      job.GetName(),
+				Namespace: job.GetNamespace(),
+			})
+			return r.ManageError(ctx, instance, err)
+		}
 
-				// copy secret to the operator namespace
-				newSecret := &corev1.Secret{}
-				err = r.GetClient().Get(context.TODO(), types.NamespacedName{
-					Namespace: operatorNs,
-					Name:      secretName,
-				}, newSecret)
+		// look up user secret and copy it to operator namespace
+		if instance.Spec.UploadTarget != nil && instance.Spec.UploadTarget.SFTP != nil && instance.Spec.UploadTarget.SFTP.CaseManagementAccountSecretRef.Name != "" {
+			secretName := instance.Spec.UploadTarget.SFTP.CaseManagementAccountSecretRef.Name
+			userSecret := &corev1.Secret{}
+			err = r.GetClient().Get(ctx, types.NamespacedName{
+				Namespace: instance.Namespace,
+				Name:      secretName,
+			}, userSecret)
+			if err != nil {
 				if errors.IsNotFound(err) {
-					newSecret.Name = secretName
-					newSecret.Namespace = operatorNs
-					newSecret.Data = userSecret.Data
-					newSecret.Type = userSecret.Type
-					err = r.GetClient().Create(context.TODO(), newSecret)
-					if err != nil {
-						log.Error(err, fmt.Sprintf("Error creating new secret %s", secretName))
-						return reconcile.Result{Requeue: true}, err
-					}
-				} else if err != nil {
+					log.Error(err, fmt.Sprintf("the secret %s was not found in namespace %s", secretName, instance.Namespace))
+					return reconcile.Result{}, nil
+				}
+				log.Error(err, fmt.Sprintf("Error getting secret (%s)", secretName))
+				return reconcile.Result{Requeue: true}, err
+			}
+
+			// copy secret in the operator namespace
+			newSecret := &corev1.Secret{}
+			err = r.GetClient().Get(ctx, types.NamespacedName{
+				Namespace: operatorNs,
+				Name:      secretName,
+			}, newSecret)
+			if err != nil {
+				if !errors.IsNotFound(err) {
 					log.Error(err, fmt.Sprintf("Error getting new secret %s", secretName))
 					return reconcile.Result{}, err
 				}
-				log.Info(fmt.Sprintf("Secret %s already exists in the %s namespace", secretName, operatorNs))
+				newSecret.Name = secretName
+				newSecret.Namespace = operatorNs
+				newSecret.Data = userSecret.Data
+				newSecret.Type = userSecret.Type
+				err = r.GetClient().Create(ctx, newSecret)
+				if err != nil {
+					log.Error(err, fmt.Sprintf("Error creating new secret %s", secretName))
+					return reconcile.Result{}, err
+				}
 			}
-
-			// job is not there, create it.
-			err = r.CreateResourceIfNotExists(context.TODO(), instance, operatorNs, job)
-			if err != nil {
-				log.Error(err, "unable to create", "job", job)
-				return r.ManageError(context.TODO(), instance, err)
-			}
-			// Increment prometheus metrics for must gather total
-			localmetrics.MetricMustGatherTotal.Inc()
-			return r.ManageSuccess(context.TODO(), instance)
+			log.Info(fmt.Sprintf("Secret %s already exists in the %s namespace", secretName, operatorNs))
 		}
-		// Error reading the object - requeue the request.
-		log.Error(err, "unable to look up", "job", types.NamespacedName{
-			Name:      job.GetName(),
-			Namespace: job.GetNamespace(),
-		})
-		return r.ManageError(context.TODO(), instance, err)
+
+		// job is not there, create it.
+		err = r.CreateResourceIfNotExists(ctx, instance, operatorNs, job)
+		if err != nil {
+			log.Error(err, "unable to create", "job", job)
+			return r.ManageError(ctx, instance, err)
+		}
+		// Increment prometheus metrics for must gather total
+		localmetrics.MetricMustGatherTotal.Inc()
+		return r.ManageSuccess(ctx, instance)
 	}
 
 	// Check status of job and update any metric counts
 	if job1.Status.Active > 0 {
-		reqLogger.Info("MustGather Job pods are still running")
+		reqLogger.Info("mustgather Job pods are still running")
 	} else {
 		// if the job has been marked as Succeeded or Failed but instance has no DeletionTimestamp,
 		// requeue instance to handle resource clean-up (delete secret, job, and MustGather)
-		if job1.Status.Succeeded > 0 && instance.GetDeletionTimestamp() == nil {
-			reqLogger.Info("MustGather Job pods succeeded")
-			err := r.DeleteResourceIfExists(context.TODO(), instance)
-			return reconcile.Result{}, err
+		if job1.Status.Succeeded > 0 {
+			reqLogger.Info("mustgather Job pods succeeded")
+			// Update the MustGather CR status to indicate success
+			instance.Status.Status = "Completed"
+			instance.Status.Completed = true
+			instance.Status.Reason = "MustGather Job pods succeeded"
+			err := r.GetClient().Status().Update(ctx, instance)
+			if err != nil {
+				log.Error(err, "unable to update instance", "instance", instance)
+				return r.ManageError(ctx, instance, err)
+			}
+
+			// Clean up resources if RetainResourcesOnCompletion is false (default behavior)
+			if !instance.Spec.RetainResourcesOnCompletion {
+				err := r.cleanupMustGatherResources(ctx, reqLogger, instance, operatorNs)
+				if err != nil {
+					reqLogger.Error(err, "failed to cleanup MustGather resources")
+					return r.ManageError(ctx, instance, err)
+				}
+			}
+			return reconcile.Result{}, nil
 		}
-		if job1.Status.Failed > 0 && instance.GetDeletionTimestamp() == nil {
-			reqLogger.Info("MustGather Job pods failed")
+		if job1.Status.Failed > 0 {
+			reqLogger.Info("mustgather Job pods failed")
 			// Increment prometheus metrics for must gather errors
 			localmetrics.MetricMustGatherErrors.Inc()
-			err := r.DeleteResourceIfExists(context.TODO(), instance)
-			return reconcile.Result{}, err
+			// Update the MustGather CR status to indicate failure
+			instance.Status.Status = "Failed"
+			instance.Status.Completed = true
+			instance.Status.Reason = "MustGather Job pods failed"
+			err := r.GetClient().Status().Update(ctx, instance)
+			if err != nil {
+				log.Error(err, "unable to update instance", "instance", instance)
+				return r.ManageError(ctx, instance, err)
+			}
+
+			// Clean up resources if RetainResourcesOnCompletion is false (default behavior)
+			if !instance.Spec.RetainResourcesOnCompletion {
+				err := r.cleanupMustGatherResources(ctx, reqLogger, instance, operatorNs)
+				if err != nil {
+					reqLogger.Error(err, "failed to cleanup MustGather resources")
+					return r.ManageError(ctx, instance, err)
+				}
+			}
+			return reconcile.Result{}, nil
 		}
 	}
 
@@ -290,14 +284,14 @@ func (r *MustGatherReconciler) Reconcile(ctx context.Context, request reconcile.
 	// 1. the mustgather instance was updated, which we don't support and we are going to ignore
 	// 2. the job was updated, probably the status piece. we should the update the status of the instance, not supported yet.
 
-	return r.updateStatus(instance, job1)
+	return r.updateStatus(ctx, instance, job1)
 
 }
 
-func (r *MustGatherReconciler) updateStatus(instance *mustgatherv1alpha1.MustGather, job *batchv1.Job) (reconcile.Result, error) {
+func (r *MustGatherReconciler) updateStatus(ctx context.Context, instance *mustgatherv1alpha1.MustGather, job *batchv1.Job) (reconcile.Result, error) {
 	instance.Status.Completed = !job.Status.CompletionTime.IsZero()
 
-	return r.ManageSuccess(context.TODO(), instance)
+	return r.ManageSuccess(ctx, instance)
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -308,7 +302,7 @@ func (r *MustGatherReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func (r *MustGatherReconciler) IsInitialized(instance *mustgatherv1alpha1.MustGather) bool {
+func (r *MustGatherReconciler) IsInitialized(ctx context.Context, instance *mustgatherv1alpha1.MustGather) bool {
 	initialized := true
 
 	if instance.Spec.ServiceAccountRef.Name == "" {
@@ -317,7 +311,7 @@ func (r *MustGatherReconciler) IsInitialized(instance *mustgatherv1alpha1.MustGa
 	}
 	if reflect.DeepEqual(instance.Spec.ProxyConfig, configv1.ProxySpec{}) {
 		platformProxy := &configv1.Proxy{}
-		err := r.GetClient().Get(context.TODO(), types.NamespacedName{Name: "cluster"}, platformProxy)
+		err := r.GetClient().Get(ctx, types.NamespacedName{Name: "cluster"}, platformProxy)
 		if err != nil {
 			log.Error(err, "unable to find cluster proxy configuration")
 		} else {
@@ -333,12 +327,12 @@ func (r *MustGatherReconciler) IsInitialized(instance *mustgatherv1alpha1.MustGa
 }
 
 // addFinalizer is a function that adds a finalizer for the MustGather CR
-func (r *MustGatherReconciler) addFinalizer(reqLogger logr.Logger, m *mustgatherv1alpha1.MustGather) error {
+func (r *MustGatherReconciler) addFinalizer(ctx context.Context, reqLogger logr.Logger, m *mustgatherv1alpha1.MustGather) error {
 	reqLogger.Info("Adding Finalizer for the MustGather")
 	m.SetFinalizers(append(m.GetFinalizers(), mustGatherFinalizer))
 
 	// Update CR
-	err := r.GetClient().Update(context.TODO(), m)
+	err := r.GetClient().Update(ctx, m)
 	if err != nil {
 		reqLogger.Error(err, "Failed to update MustGather with finalizer")
 		return err
@@ -346,7 +340,7 @@ func (r *MustGatherReconciler) addFinalizer(reqLogger logr.Logger, m *mustgather
 	return nil
 }
 
-func (r *MustGatherReconciler) getJobFromInstance(instance *mustgatherv1alpha1.MustGather) (*batchv1.Job, error) {
+func (r *MustGatherReconciler) getJobFromInstance(ctx context.Context, instance *mustgatherv1alpha1.MustGather) (*batchv1.Job, error) {
 	// Inject the operator image URI from the pod's env variables
 	operatorImage, varPresent := os.LookupEnv("OPERATOR_IMAGE")
 	if !varPresent {
@@ -376,4 +370,79 @@ func remove(list []string, s string) []string {
 		}
 	}
 	return list
+}
+
+// cleanupMustGatherResources cleans up the secret, job, and pods associated with a MustGather instance
+func (r *MustGatherReconciler) cleanupMustGatherResources(ctx context.Context, reqLogger logr.Logger, instance *mustgatherv1alpha1.MustGather, operatorNs string) error {
+	reqLogger.Info("cleaning up resources")
+
+	// delete secret in the operator namespace
+	if instance.Spec.UploadTarget != nil && instance.Spec.UploadTarget.SFTP != nil && instance.Spec.UploadTarget.SFTP.CaseManagementAccountSecretRef.Name != "" {
+		tmpSecretName := instance.Spec.UploadTarget.SFTP.CaseManagementAccountSecretRef.Name
+		tmpSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      tmpSecretName,
+				Namespace: operatorNs,
+			},
+		}
+
+		err := r.DeleteResourceIfExists(ctx, tmpSecret)
+
+		if err != nil {
+			reqLogger.Error(err, fmt.Sprintf("failed to delete %s secret", tmpSecretName))
+			return err
+		}
+		reqLogger.Info(fmt.Sprintf("successfully deleted secret %s", tmpSecretName))
+	}
+
+	// delete job from operator namespace
+	tmpJob := &batchv1.Job{}
+	err = r.GetClient().Get(ctx, types.NamespacedName{
+		Namespace: operatorNs,
+		Name:      instance.Name,
+	}, tmpJob)
+
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			reqLogger.Info(fmt.Sprintf("failed to get %s job", instance.Name))
+			return err
+		}
+		reqLogger.Info(fmt.Sprintf("job %s not found", instance.Name))
+		reqLogger.V(4).Info("successfully cleaned up mustgather resources")
+		return nil
+	}
+
+	// delete pods owned by job
+	podList := &corev1.PodList{}
+	listOpts := []client.ListOption{
+		client.InNamespace(operatorNs),
+		client.MatchingLabels{"controller-uid": string(tmpJob.UID)},
+	}
+
+	if err = r.GetClient().List(ctx, podList, listOpts...); err != nil {
+		reqLogger.Error(err, "failed to list pods", "Namespace", operatorNs, "UID", tmpJob.UID)
+		return err
+	}
+
+	podObjs := make([]client.Object, len(podList.Items))
+	for i, tmpPod := range podList.Items {
+		podObjs[i] = &tmpPod
+	}
+	err = r.DeleteResourcesIfExist(ctx, podObjs)
+	if err != nil {
+		reqLogger.Error(err, fmt.Sprintf("failed to delete pods for job %s", tmpJob.Name))
+		return err
+	}
+	reqLogger.Info(fmt.Sprintf("deleted pods for job %s", tmpJob.Name))
+
+	// finally delete job
+	err = r.GetClient().Delete(ctx, tmpJob)
+	if err != nil {
+		reqLogger.Error(err, fmt.Sprintf("failed to delete %s job", tmpJob.Name))
+		return err
+	}
+	reqLogger.Info(fmt.Sprintf("deleted job %s", tmpJob.Name))
+
+	reqLogger.V(4).Info("successfully cleaned up mustgather resources")
+	return nil
 }

--- a/controllers/mustgather/mustgather_controller_test.go
+++ b/controllers/mustgather/mustgather_controller_test.go
@@ -2,10 +2,15 @@ package mustgather
 
 import (
 	"context"
+	"errors"
+	"os"
 	"testing"
+	"time"
 
+	configv1 "github.com/openshift/api/config/v1"
 	mustgatherv1alpha1 "github.com/openshift/must-gather-operator/api/v1alpha1"
 	"github.com/redhat-cop/operator-utils/pkg/util"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -18,16 +23,1072 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-func generateFakeClient(objs ...runtime.Object) (client.Client, *runtime.Scheme) {
-	s := scheme.Scheme
-	s.AddKnownTypes(mustgatherv1alpha1.GroupVersion, &mustgatherv1alpha1.MustGather{})
-	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
-	return cl, s
+// interceptClient allows injecting failures for specific CRUD operations
+type interceptClient struct {
+	client.Client
+	onGet    func(ctx context.Context, key client.ObjectKey, obj client.Object) error
+	onList   func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error
+	onDelete func(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error
+	onUpdate func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error
+	onCreate func(ctx context.Context, obj client.Object, opts ...client.CreateOption) error
+	status   client.StatusWriter
 }
 
+func (c interceptClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if c.onGet != nil {
+		if err := c.onGet(ctx, key, obj); err != nil {
+			return err
+		}
+	}
+	return c.Client.Get(ctx, key, obj, opts...)
+}
+func (c interceptClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	if c.onList != nil {
+		if err := c.onList(ctx, list, opts...); err != nil {
+			return err
+		}
+	}
+	return c.Client.List(ctx, list, opts...)
+}
+func (c interceptClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	if c.onDelete != nil {
+		if err := c.onDelete(ctx, obj, opts...); err != nil {
+			return err
+		}
+	}
+	return c.Client.Delete(ctx, obj, opts...)
+}
+func (c interceptClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	if c.onUpdate != nil {
+		if err := c.onUpdate(ctx, obj, opts...); err != nil {
+			return err
+		}
+	}
+	return c.Client.Update(ctx, obj, opts...)
+}
+func (c interceptClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	if c.onCreate != nil {
+		if err := c.onCreate(ctx, obj, opts...); err != nil {
+			return err
+		}
+	}
+	return c.Client.Create(ctx, obj, opts...)
+}
+func (c interceptClient) Status() client.StatusWriter {
+	if c.status != nil {
+		return c.status
+	}
+	return c.Client.Status()
+}
+
+// failingStatusWriter wraps a client.StatusWriter and forces Status().Update to return an error
+type failingStatusWriter struct{ client.StatusWriter }
+
+func (w failingStatusWriter) Update(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+	return errors.New("forced status update error")
+}
+
+func TestCleanupMustGatherResources(t *testing.T) {
+	operatorNs := "must-gather-operator"
+
+	tests := []struct {
+		name           string
+		setupObjects   func() []client.Object
+		interceptors   func() interceptClient
+		expectError    bool
+		postTestChecks func(t *testing.T, cl client.Client)
+	}{
+		{
+			name: "cleanup_success_all_resources_deleted",
+			setupObjects: func() []client.Object {
+				mg := &mustgatherv1alpha1.MustGather{
+					ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: operatorNs},
+					Spec: mustgatherv1alpha1.MustGatherSpec{
+						UploadTarget: &mustgatherv1alpha1.UploadTargetSpec{
+							Type: mustgatherv1alpha1.UploadTypeSFTP,
+							SFTP: &mustgatherv1alpha1.SFTPSpec{
+								CaseID:                         "12345678",
+								CaseManagementAccountSecretRef: corev1.LocalObjectReference{Name: "case-management-creds"},
+							},
+						},
+					},
+				}
+				secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "case-management-creds", Namespace: operatorNs}}
+				job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: mg.Name, Namespace: operatorNs, UID: "user-123"}}
+				pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: operatorNs, Labels: map[string]string{"controller-uid": string(job.UID)}}}
+				return []client.Object{mg, secret, job, pod}
+			},
+			interceptors: func() interceptClient { return interceptClient{} },
+			expectError:  false,
+			postTestChecks: func(t *testing.T, cl client.Client) {
+				// Verify secret is deleted
+				chkSecret := &corev1.Secret{}
+				if getErr := cl.Get(context.TODO(), types.NamespacedName{Namespace: operatorNs, Name: "case-management-creds"}, chkSecret); getErr == nil {
+					t.Fatalf("expected secret to be deleted")
+				}
+				// Verify job is deleted
+				chkJob := &batchv1.Job{}
+				if getErr := cl.Get(context.TODO(), types.NamespacedName{Namespace: operatorNs, Name: "example-mustgather"}, chkJob); getErr == nil {
+					t.Fatalf("expected job to be deleted")
+				}
+			},
+		},
+		{
+			name: "cleanup_job_get_error_continues_successfully",
+			setupObjects: func() []client.Object {
+				mg := &mustgatherv1alpha1.MustGather{
+					ObjectMeta: metav1.ObjectMeta{Name: "mg", Namespace: operatorNs},
+					Spec:       mustgatherv1alpha1.MustGatherSpec{},
+				}
+				return []client.Object{mg}
+			},
+			interceptors: func() interceptClient {
+				return interceptClient{
+					onGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+						if _, ok := obj.(*batchv1.Job); ok && key.Name == "mg" {
+							return errors.New("failed to get job")
+						}
+						return nil
+					},
+				}
+			},
+			expectError:    true,
+			postTestChecks: func(t *testing.T, cl client.Client) {},
+		},
+		{
+			name: "cleanup_pod_list_error_leaves_job_intact",
+			setupObjects: func() []client.Object {
+				mg := &mustgatherv1alpha1.MustGather{
+					ObjectMeta: metav1.ObjectMeta{Name: "mg", Namespace: operatorNs},
+					Spec:       mustgatherv1alpha1.MustGatherSpec{},
+				}
+				job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: mg.Name, Namespace: operatorNs, UID: "u"}}
+				return []client.Object{mg, job}
+			},
+			interceptors: func() interceptClient {
+				return interceptClient{
+					onList: func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+						if _, ok := list.(*corev1.PodList); ok {
+							return errors.New("failed to list pods")
+						}
+						return nil
+					},
+				}
+			},
+			expectError: true,
+			postTestChecks: func(t *testing.T, cl client.Client) {
+				// Since cleanup failed due to pod list error, job should still exist
+				chk := &batchv1.Job{}
+				if e := cl.Get(context.TODO(), types.NamespacedName{Namespace: operatorNs, Name: "mg"}, chk); e != nil {
+					t.Fatalf("expected job to remain after failed cleanup, get err: %v", e)
+				}
+			},
+		},
+		{
+			name: "cleanup_pod_delete_error_returns_error",
+			setupObjects: func() []client.Object {
+				mg := &mustgatherv1alpha1.MustGather{
+					ObjectMeta: metav1.ObjectMeta{Name: "mg", Namespace: operatorNs},
+					Spec:       mustgatherv1alpha1.MustGatherSpec{},
+				}
+				job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: mg.Name, Namespace: operatorNs, UID: "u"}}
+				pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p1", Namespace: operatorNs, Labels: map[string]string{"controller-uid": string(job.UID)}}}
+				return []client.Object{mg, job, pod}
+			},
+			interceptors: func() interceptClient {
+				return interceptClient{
+					onDelete: func(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+						if _, ok := obj.(*corev1.Pod); ok {
+							return errors.New("failed to delete pod")
+						}
+						return nil
+					},
+				}
+			},
+			expectError:    true,
+			postTestChecks: func(t *testing.T, cl client.Client) {},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup scheme
+			s := runtime.NewScheme()
+			_ = corev1.AddToScheme(s)
+			_ = batchv1.AddToScheme(s)
+			_ = mustgatherv1alpha1.AddToScheme(s)
+
+			// Setup objects and client
+			objects := tt.setupObjects()
+			base := fake.NewClientBuilder().WithScheme(s).WithObjects(objects...).Build()
+
+			// Setup interceptor if needed
+			interceptor := tt.interceptors()
+			var cl client.Client = base
+			if interceptor.onGet != nil || interceptor.onList != nil || interceptor.onDelete != nil || interceptor.onUpdate != nil || interceptor.onCreate != nil || interceptor.status != nil {
+				interceptor.Client = base
+				cl = interceptor
+			}
+
+			// Create reconciler
+			r := &MustGatherReconciler{ReconcilerBase: util.NewReconcilerBase(cl, s, &rest.Config{}, &record.FakeRecorder{}, nil)}
+
+			// Get the MustGather object for the test
+			var mg *mustgatherv1alpha1.MustGather
+			for _, obj := range objects {
+				if mgObj, ok := obj.(*mustgatherv1alpha1.MustGather); ok {
+					mg = mgObj
+					break
+				}
+			}
+
+			// Execute
+			err := r.cleanupMustGatherResources(context.TODO(), logf.Log, mg, operatorNs)
+
+			// Assert error expectation
+			if tt.expectError && err == nil {
+				t.Fatalf("expected error but got none")
+			}
+			if !tt.expectError && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			// Run post-test checks
+			tt.postTestChecks(t, cl)
+		})
+	}
+}
+
+func TestReconcile(t *testing.T) {
+	const operatorNs = "must-gather-operator"
+
+	tests := []struct {
+		name           string
+		setupEnv       func(t *testing.T)
+		setupObjects   func() []client.Object
+		interceptors   func() interceptClient
+		expectError    bool
+		expectResult   reconcile.Result
+		postTestChecks func(t *testing.T, cl client.Client)
+	}{
+		{
+			name:     "reconcile_mustgather_not_found_returns_empty_result",
+			setupEnv: func(t *testing.T) {},
+			setupObjects: func() []client.Object {
+				return []client.Object{}
+			},
+			interceptors:   func() interceptClient { return interceptClient{} },
+			expectError:    false,
+			expectResult:   reconcile.Result{},
+			postTestChecks: func(t *testing.T, cl client.Client) {},
+		},
+		{
+			name:     "reconcile_mustgather_get_error_returns_error",
+			setupEnv: func(t *testing.T) {},
+			setupObjects: func() []client.Object {
+				return []client.Object{}
+			},
+			interceptors: func() interceptClient {
+				return interceptClient{
+					onGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+						if _, ok := obj.(*mustgatherv1alpha1.MustGather); ok {
+							return errors.New("failed to get mustgather")
+						}
+						return nil
+					},
+				}
+			},
+			expectError:    true,
+			expectResult:   reconcile.Result{},
+			postTestChecks: func(t *testing.T, cl client.Client) {},
+		},
+		{
+			name:     "reconcile_initialize_mustgather_update_succeeds",
+			setupEnv: func(t *testing.T) {},
+			setupObjects: func() []client.Object {
+				mg := &mustgatherv1alpha1.MustGather{ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: "ns"}}
+				return []client.Object{mg}
+			},
+			interceptors:   func() interceptClient { return interceptClient{} },
+			expectError:    false,
+			expectResult:   reconcile.Result{},
+			postTestChecks: func(t *testing.T, cl client.Client) {},
+		},
+		{
+			name:     "reconcile_initialize_mustgather_update_fails",
+			setupEnv: func(t *testing.T) {},
+			setupObjects: func() []client.Object {
+				mg := &mustgatherv1alpha1.MustGather{ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: "ns"}}
+				return []client.Object{mg}
+			},
+			interceptors: func() interceptClient {
+				return interceptClient{
+					onUpdate: func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+						if _, ok := obj.(*mustgatherv1alpha1.MustGather); ok {
+							return errors.New("failed to update mustgather")
+						}
+						return nil
+					},
+				}
+			},
+			expectError:    true,
+			expectResult:   reconcile.Result{},
+			postTestChecks: func(t *testing.T, cl client.Client) {},
+		},
+		{
+			name:     "reconcile_deletion_cleanup_and_finalizer_removal_success",
+			setupEnv: func(t *testing.T) {},
+			setupObjects: func() []client.Object {
+				secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: operatorNs}}
+				mg := &mustgatherv1alpha1.MustGather{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "example-mustgather", Namespace: operatorNs,
+						Finalizers:        []string{mustGatherFinalizer},
+						DeletionTimestamp: &metav1.Time{Time: time.Now()},
+					},
+					Spec: mustgatherv1alpha1.MustGatherSpec{
+						ServiceAccountRef: corev1.LocalObjectReference{Name: "default"},
+						UploadTarget: &mustgatherv1alpha1.UploadTargetSpec{
+							Type: mustgatherv1alpha1.UploadTypeSFTP,
+							SFTP: &mustgatherv1alpha1.SFTPSpec{
+								CaseID:                         "12345678",
+								CaseManagementAccountSecretRef: corev1.LocalObjectReference{Name: "s"},
+							},
+						},
+					},
+				}
+				return []client.Object{mg, secret}
+			},
+			interceptors: func() interceptClient { return interceptClient{} },
+			expectError:  false,
+			expectResult: reconcile.Result{},
+			postTestChecks: func(t *testing.T, cl client.Client) {
+				out := &mustgatherv1alpha1.MustGather{}
+				_ = cl.Get(context.TODO(), types.NamespacedName{Name: "example-mustgather", Namespace: operatorNs}, out)
+				if contains(out.GetFinalizers(), mustGatherFinalizer) {
+					t.Fatalf("expected finalizer removed")
+				}
+			},
+		},
+		{
+			name: "reconcile_deletion_cleanup_resources_returns_error",
+			setupEnv: func(t *testing.T) {
+				t.Setenv("OSDK_FORCE_RUN_MODE", "local")
+			},
+			setupObjects: func() []client.Object {
+				mg := &mustgatherv1alpha1.MustGather{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "example-mustgather", Namespace: operatorNs,
+						Finalizers:        []string{mustGatherFinalizer},
+						DeletionTimestamp: &metav1.Time{Time: time.Now()},
+					},
+					Spec: mustgatherv1alpha1.MustGatherSpec{
+						ServiceAccountRef: corev1.LocalObjectReference{Name: "default"},
+						UploadTarget: &mustgatherv1alpha1.UploadTargetSpec{
+							Type: mustgatherv1alpha1.UploadTypeSFTP,
+							SFTP: &mustgatherv1alpha1.SFTPSpec{
+								CaseID:                         "12345678",
+								CaseManagementAccountSecretRef: corev1.LocalObjectReference{Name: "s"},
+							},
+						},
+					},
+				}
+				secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: operatorNs}}
+				return []client.Object{mg, secret}
+			},
+			interceptors: func() interceptClient {
+				return interceptClient{
+					onDelete: func(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+						if _, ok := obj.(*corev1.Secret); ok {
+							return errors.New("failed to delete secret")
+						}
+						return nil
+					},
+				}
+			},
+			expectError:    true,
+			expectResult:   reconcile.Result{},
+			postTestChecks: func(t *testing.T, cl client.Client) {},
+		},
+		{
+			name: "reconcile_job_template_env_missing_returns_error",
+			setupEnv: func(t *testing.T) {
+				osUnset := os.Getenv("OPERATOR_IMAGE")
+				_ = os.Unsetenv("OPERATOR_IMAGE")
+				t.Cleanup(func() { os.Setenv("OPERATOR_IMAGE", osUnset) })
+			},
+			setupObjects: func() []client.Object {
+				mg := &mustgatherv1alpha1.MustGather{
+					ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: "ns"},
+					Spec: mustgatherv1alpha1.MustGatherSpec{
+						ServiceAccountRef: corev1.LocalObjectReference{Name: "default"},
+					},
+				}
+				return []client.Object{mg}
+			},
+			interceptors:   func() interceptClient { return interceptClient{} },
+			expectError:    true,
+			expectResult:   reconcile.Result{},
+			postTestChecks: func(t *testing.T, cl client.Client) {},
+		},
+		{
+			name: "reconcile_job_not_found_no_upload_target_creates_job_successfully",
+			setupEnv: func(t *testing.T) {
+				os.Setenv("OPERATOR_IMAGE", "img")
+			},
+			setupObjects: func() []client.Object {
+				mg := &mustgatherv1alpha1.MustGather{
+					ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: "ns", Finalizers: []string{mustGatherFinalizer}},
+					Spec: mustgatherv1alpha1.MustGatherSpec{
+						ServiceAccountRef: corev1.LocalObjectReference{Name: "default"},
+					},
+				}
+				return []client.Object{mg}
+			},
+			interceptors:   func() interceptClient { return interceptClient{} },
+			expectError:    false,
+			expectResult:   reconcile.Result{},
+			postTestChecks: func(t *testing.T, cl client.Client) {},
+		},
+		{
+			name: "reconcile_job_not_found_creates_job_successfully",
+			setupEnv: func(t *testing.T) {
+				t.Setenv("OSDK_FORCE_RUN_MODE", "local")
+				os.Setenv("OPERATOR_IMAGE", "img")
+			},
+			setupObjects: func() []client.Object {
+				mg := &mustgatherv1alpha1.MustGather{
+					ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: "ns", Finalizers: []string{mustGatherFinalizer}},
+					Spec: mustgatherv1alpha1.MustGatherSpec{
+						ServiceAccountRef: corev1.LocalObjectReference{Name: "default"},
+						UploadTarget: &mustgatherv1alpha1.UploadTargetSpec{
+							Type: mustgatherv1alpha1.UploadTypeSFTP,
+							SFTP: &mustgatherv1alpha1.SFTPSpec{
+								CaseID:                         "12345678",
+								CaseManagementAccountSecretRef: corev1.LocalObjectReference{Name: "secret"},
+							},
+						},
+					},
+				}
+				userSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "secret", Namespace: "ns"}}
+				cv := &configv1.ClusterVersion{
+					ObjectMeta: metav1.ObjectMeta{Name: "version"},
+					Status: configv1.ClusterVersionStatus{
+						History: []configv1.UpdateHistory{{State: "Completed", Version: "1.2.3"}},
+					},
+				}
+				return []client.Object{mg, userSecret, cv}
+			},
+			interceptors: func() interceptClient { return interceptClient{} },
+			expectError:  false,
+			expectResult: reconcile.Result{},
+			postTestChecks: func(t *testing.T, cl client.Client) {
+				// Verify secret was created in operator namespace
+				operatorSecret := &corev1.Secret{}
+				if err := cl.Get(context.TODO(), types.NamespacedName{Namespace: defaultMustGatherNamespace, Name: "secret"}, operatorSecret); err != nil {
+					t.Fatalf("expected secret to be created in operator namespace, got error: %v", err)
+				}
+
+				// Verify job was created
+				job := &batchv1.Job{}
+				if err := cl.Get(context.TODO(), types.NamespacedName{Namespace: defaultMustGatherNamespace, Name: "example-mustgather"}, job); err != nil {
+					t.Fatalf("expected job to be created, got error: %v", err)
+				}
+			},
+		},
+		{
+			name: "reconcile_job_not_found_user_secret_missing_no_requeue",
+			setupEnv: func(t *testing.T) {
+				os.Setenv("OPERATOR_IMAGE", "img")
+			},
+			setupObjects: func() []client.Object {
+				mg := &mustgatherv1alpha1.MustGather{
+					ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: "ns", Finalizers: []string{mustGatherFinalizer}},
+					Spec: mustgatherv1alpha1.MustGatherSpec{
+						ServiceAccountRef: corev1.LocalObjectReference{Name: "default"},
+						UploadTarget: &mustgatherv1alpha1.UploadTargetSpec{
+							Type: mustgatherv1alpha1.UploadTypeSFTP,
+							SFTP: &mustgatherv1alpha1.SFTPSpec{
+								CaseID:                         "12345678",
+								CaseManagementAccountSecretRef: corev1.LocalObjectReference{Name: "sec"},
+							},
+						},
+					},
+				}
+				cv := &configv1.ClusterVersion{
+					ObjectMeta: metav1.ObjectMeta{Name: "version"},
+					Status: configv1.ClusterVersionStatus{
+						History: []configv1.UpdateHistory{{State: "Completed", Version: "1.2.3"}},
+					},
+				}
+				return []client.Object{mg, cv}
+			},
+			interceptors:   func() interceptClient { return interceptClient{} },
+			expectError:    false,
+			expectResult:   reconcile.Result{},
+			postTestChecks: func(t *testing.T, cl client.Client) {},
+		},
+		{
+			name: "reconcile_job_active_updates_status_running",
+			setupEnv: func(t *testing.T) {
+				os.Setenv("OPERATOR_IMAGE", "img")
+			},
+			setupObjects: func() []client.Object {
+				mg := &mustgatherv1alpha1.MustGather{
+					ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: "ns", Finalizers: []string{mustGatherFinalizer}},
+					Spec: mustgatherv1alpha1.MustGatherSpec{
+						ServiceAccountRef: corev1.LocalObjectReference{Name: "default"},
+					},
+				}
+				userSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "sec", Namespace: "ns"}}
+				cv := &configv1.ClusterVersion{
+					ObjectMeta: metav1.ObjectMeta{Name: "version"},
+					Status: configv1.ClusterVersionStatus{
+						History: []configv1.UpdateHistory{{State: "Completed", Version: "1.2.3"}},
+					},
+				}
+				job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: "ns"}}
+				job.Status.Active = 1
+				return []client.Object{mg, userSecret, cv, job}
+			},
+			interceptors:   func() interceptClient { return interceptClient{} },
+			expectError:    false,
+			expectResult:   reconcile.Result{},
+			postTestChecks: func(t *testing.T, cl client.Client) {},
+		},
+		{
+			name: "reconcile_job_succeeded_retain_resources_no_cleanup",
+			setupEnv: func(t *testing.T) {
+				os.Setenv("OPERATOR_IMAGE", "img")
+			},
+			setupObjects: func() []client.Object {
+				mg := &mustgatherv1alpha1.MustGather{
+					ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: operatorNs, Finalizers: []string{mustGatherFinalizer}},
+					Spec: mustgatherv1alpha1.MustGatherSpec{
+						ServiceAccountRef:           corev1.LocalObjectReference{Name: "default"},
+						RetainResourcesOnCompletion: true,
+					},
+				}
+				userSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "sec", Namespace: operatorNs}}
+				job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: operatorNs}}
+				job.Status.Succeeded = 1
+				cv := &configv1.ClusterVersion{
+					ObjectMeta: metav1.ObjectMeta{Name: "version"},
+					Status: configv1.ClusterVersionStatus{
+						History: []configv1.UpdateHistory{{State: "Completed", Version: "1.2.3"}},
+					},
+				}
+				return []client.Object{mg, userSecret, cv, job}
+			},
+			interceptors: func() interceptClient { return interceptClient{} },
+			expectError:  false,
+			expectResult: reconcile.Result{},
+			postTestChecks: func(t *testing.T, cl client.Client) {
+				chk := &batchv1.Job{}
+				if e := cl.Get(context.TODO(), types.NamespacedName{Namespace: operatorNs, Name: "example-mustgather"}, chk); e != nil {
+					t.Fatalf("expected job to remain, err: %v", e)
+				}
+			},
+		},
+		{
+			name: "reconcile_job_succeeded_cleanup_error_returns_error",
+			setupEnv: func(t *testing.T) {
+				t.Setenv("OSDK_FORCE_RUN_MODE", "local")
+				os.Setenv("OPERATOR_IMAGE", "img")
+			},
+			setupObjects: func() []client.Object {
+				mg := &mustgatherv1alpha1.MustGather{
+					ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: operatorNs, Finalizers: []string{mustGatherFinalizer}},
+					Spec: mustgatherv1alpha1.MustGatherSpec{
+						ServiceAccountRef: corev1.LocalObjectReference{Name: "default"},
+					},
+				}
+				userSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "sec", Namespace: operatorNs}}
+				job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: operatorNs}}
+				job.Status.Succeeded = 1
+				cv := &configv1.ClusterVersion{
+					ObjectMeta: metav1.ObjectMeta{Name: "version"},
+					Status: configv1.ClusterVersionStatus{
+						History: []configv1.UpdateHistory{{State: "Completed", Version: "1.2.3"}},
+					},
+				}
+				return []client.Object{mg, userSecret, cv, job}
+			},
+			interceptors: func() interceptClient {
+				return interceptClient{
+					onDelete: func(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+						if _, ok := obj.(*batchv1.Job); ok {
+							return errors.New("failed to delete job")
+						}
+						return nil
+					},
+				}
+			},
+			expectError:    true,
+			expectResult:   reconcile.Result{},
+			postTestChecks: func(t *testing.T, cl client.Client) {},
+		},
+		{
+			name: "reconcile_job_failed_cleanup_error_returns_error",
+			setupEnv: func(t *testing.T) {
+				t.Setenv("OSDK_FORCE_RUN_MODE", "local")
+				os.Setenv("OPERATOR_IMAGE", "img")
+			},
+			setupObjects: func() []client.Object {
+				mg := &mustgatherv1alpha1.MustGather{
+					ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: operatorNs, Finalizers: []string{mustGatherFinalizer}},
+					Spec: mustgatherv1alpha1.MustGatherSpec{
+						ServiceAccountRef: corev1.LocalObjectReference{Name: "default"},
+						UploadTarget: &mustgatherv1alpha1.UploadTargetSpec{
+							Type: mustgatherv1alpha1.UploadTypeSFTP,
+							SFTP: &mustgatherv1alpha1.SFTPSpec{
+								CaseID:                         "12345678",
+								CaseManagementAccountSecretRef: corev1.LocalObjectReference{Name: "sec"},
+							},
+						},
+					},
+				}
+				userSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "sec", Namespace: operatorNs}}
+				job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: operatorNs}}
+				job.Status.Failed = 1
+				cv := &configv1.ClusterVersion{
+					ObjectMeta: metav1.ObjectMeta{Name: "version"},
+					Status: configv1.ClusterVersionStatus{
+						History: []configv1.UpdateHistory{{State: "Completed", Version: "1.2.3"}},
+					},
+				}
+				return []client.Object{mg, userSecret, cv, job}
+			},
+			interceptors: func() interceptClient {
+				return interceptClient{
+					onDelete: func(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+						if _, ok := obj.(*corev1.Secret); ok {
+							return errors.New("failed to delete secret")
+						}
+						return nil
+					},
+				}
+			},
+			expectError:    true,
+			expectResult:   reconcile.Result{},
+			postTestChecks: func(t *testing.T, cl client.Client) {},
+		},
+		{
+			name: "reconcile_job_failed_retain_resources_no_cleanup",
+			setupEnv: func(t *testing.T) {
+				os.Setenv("OPERATOR_IMAGE", "img")
+			},
+			setupObjects: func() []client.Object {
+				mg := &mustgatherv1alpha1.MustGather{
+					ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: "ns", Finalizers: []string{mustGatherFinalizer}},
+					Spec: mustgatherv1alpha1.MustGatherSpec{
+						ServiceAccountRef:           corev1.LocalObjectReference{Name: "default"},
+						RetainResourcesOnCompletion: true,
+					},
+				}
+				job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: "ns"}}
+				job.Status.Failed = 1
+				cv := &configv1.ClusterVersion{
+					ObjectMeta: metav1.ObjectMeta{Name: "version"},
+					Status: configv1.ClusterVersionStatus{
+						History: []configv1.UpdateHistory{{State: "Completed", Version: "1.2.3"}},
+					},
+				}
+				return []client.Object{mg, cv, job}
+			},
+			interceptors: func() interceptClient { return interceptClient{} },
+			expectError:  false,
+			expectResult: reconcile.Result{},
+			postTestChecks: func(t *testing.T, cl client.Client) {
+				out := &mustgatherv1alpha1.MustGather{}
+				if getErr := cl.Get(context.TODO(), types.NamespacedName{Name: "example-mustgather", Namespace: "ns"}, out); getErr != nil {
+					t.Fatalf("failed to get mustgather: %v", getErr)
+				}
+				if !out.Status.Completed || out.Status.Status != "Failed" || out.Status.Reason != "MustGather Job pods failed" {
+					t.Fatalf("unexpected status after failed without cleanup: %+v", out.Status)
+				}
+			},
+		},
+		{
+			name: "reconcile_job_succeeded_status_update_fails",
+			setupEnv: func(t *testing.T) {
+				os.Setenv("OPERATOR_IMAGE", "img")
+			},
+			setupObjects: func() []client.Object {
+				mg := &mustgatherv1alpha1.MustGather{
+					ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: operatorNs, Finalizers: []string{mustGatherFinalizer}},
+					Spec: mustgatherv1alpha1.MustGatherSpec{
+						ServiceAccountRef: corev1.LocalObjectReference{Name: "default"},
+					},
+				}
+				userSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "sec", Namespace: operatorNs}}
+				job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: operatorNs}}
+				job.Status.Succeeded = 1
+				cv := &configv1.ClusterVersion{
+					ObjectMeta: metav1.ObjectMeta{Name: "version"},
+					Status: configv1.ClusterVersionStatus{
+						History: []configv1.UpdateHistory{{State: "Completed", Version: "1.2.3"}},
+					},
+				}
+				return []client.Object{mg, userSecret, cv, job}
+			},
+			interceptors: func() interceptClient {
+				return interceptClient{
+					status: &failingStatusWriter{},
+				}
+			},
+			expectError:    true,
+			expectResult:   reconcile.Result{},
+			postTestChecks: func(t *testing.T, cl client.Client) {},
+		},
+		{
+			name: "reconcile_job_failed_status_update_fails",
+			setupEnv: func(t *testing.T) {
+				os.Setenv("OPERATOR_IMAGE", "img")
+			},
+			setupObjects: func() []client.Object {
+				mg := &mustgatherv1alpha1.MustGather{
+					ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: operatorNs, Finalizers: []string{mustGatherFinalizer}},
+					Spec: mustgatherv1alpha1.MustGatherSpec{
+						ServiceAccountRef: corev1.LocalObjectReference{Name: "default"},
+					},
+				}
+				userSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "sec", Namespace: operatorNs}}
+				job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: operatorNs}}
+				job.Status.Failed = 1
+				cv := &configv1.ClusterVersion{
+					ObjectMeta: metav1.ObjectMeta{Name: "version"},
+					Status: configv1.ClusterVersionStatus{
+						History: []configv1.UpdateHistory{{State: "Completed", Version: "1.2.3"}},
+					},
+				}
+				return []client.Object{mg, userSecret, cv, job}
+			},
+			interceptors: func() interceptClient {
+				return interceptClient{
+					status: &failingStatusWriter{},
+				}
+			},
+			expectError:    true,
+			expectResult:   reconcile.Result{},
+			postTestChecks: func(t *testing.T, cl client.Client) {},
+		},
+		{
+			name:     "reconcile_deletion_finalizer_removal_update_fails",
+			setupEnv: func(t *testing.T) {},
+			setupObjects: func() []client.Object {
+				operatorNs := "must-gather-operator"
+				secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "secret", Namespace: operatorNs}}
+				mg := &mustgatherv1alpha1.MustGather{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "must-gather", Namespace: operatorNs,
+						Finalizers:        []string{mustGatherFinalizer},
+						DeletionTimestamp: &metav1.Time{Time: time.Now()},
+					},
+					Spec: mustgatherv1alpha1.MustGatherSpec{
+						ServiceAccountRef: corev1.LocalObjectReference{Name: "default"},
+						UploadTarget: &mustgatherv1alpha1.UploadTargetSpec{
+							Type: mustgatherv1alpha1.UploadTypeSFTP,
+							SFTP: &mustgatherv1alpha1.SFTPSpec{
+								CaseID:                         "12345678",
+								CaseManagementAccountSecretRef: corev1.LocalObjectReference{Name: "secret"},
+							},
+						},
+					},
+				}
+				return []client.Object{mg, secret}
+			},
+			interceptors: func() interceptClient {
+				updateCount := 0
+				return interceptClient{
+					onUpdate: func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+						if mgObj, ok := obj.(*mustgatherv1alpha1.MustGather); ok {
+							updateCount++
+							// Fail the update when removing finalizer (after cleanup is done)
+							if updateCount > 0 && !contains(mgObj.GetFinalizers(), mustGatherFinalizer) {
+								return errors.New("failed to remove finalizer")
+							}
+						}
+						return nil
+					},
+				}
+			},
+			expectError:    true,
+			expectResult:   reconcile.Result{},
+			postTestChecks: func(t *testing.T, cl client.Client) {},
+		},
+		{
+			name:     "reconcile_add_finalizer_fails",
+			setupEnv: func(t *testing.T) {},
+			setupObjects: func() []client.Object {
+				mg := &mustgatherv1alpha1.MustGather{
+					ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: "ns"},
+					Spec: mustgatherv1alpha1.MustGatherSpec{
+						ServiceAccountRef: corev1.LocalObjectReference{Name: "default"}, // Pre-initialized to skip IsInitialized update
+					},
+				}
+				return []client.Object{mg}
+			},
+			interceptors: func() interceptClient {
+				return interceptClient{
+					onUpdate: func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+						if mgObj, ok := obj.(*mustgatherv1alpha1.MustGather); ok {
+							// Fail when trying to add the finalizer (when finalizer is present in the object)
+							if contains(mgObj.GetFinalizers(), mustGatherFinalizer) {
+								return errors.New("failed to add finalizer")
+							}
+						}
+						return nil
+					},
+				}
+			},
+			expectError:    true,
+			expectResult:   reconcile.Result{},
+			postTestChecks: func(t *testing.T, cl client.Client) {},
+		},
+		{
+			name: "reconcile_job_not_found_create_job_fails",
+			setupEnv: func(t *testing.T) {
+				os.Setenv("OPERATOR_IMAGE", "img")
+			},
+			setupObjects: func() []client.Object {
+				mg := &mustgatherv1alpha1.MustGather{
+					ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: operatorNs, Finalizers: []string{mustGatherFinalizer}},
+					Spec: mustgatherv1alpha1.MustGatherSpec{
+						ServiceAccountRef: corev1.LocalObjectReference{Name: "default"},
+						UploadTarget: &mustgatherv1alpha1.UploadTargetSpec{
+							Type: mustgatherv1alpha1.UploadTypeSFTP,
+							SFTP: &mustgatherv1alpha1.SFTPSpec{
+								CaseID:                         "12345678",
+								CaseManagementAccountSecretRef: corev1.LocalObjectReference{Name: "secret"},
+							},
+						},
+					},
+				}
+				userSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "secret", Namespace: operatorNs}}
+				cv := &configv1.ClusterVersion{
+					ObjectMeta: metav1.ObjectMeta{Name: "version"},
+					Status: configv1.ClusterVersionStatus{
+						History: []configv1.UpdateHistory{{State: "Completed", Version: "1.2.3"}},
+					},
+				}
+				return []client.Object{mg, userSecret, cv}
+			},
+			interceptors: func() interceptClient {
+				return interceptClient{
+					onCreate: func(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+						// Fail job creation
+						if _, ok := obj.(*batchv1.Job); ok {
+							return errors.New("failed to create job")
+						}
+						return nil
+					},
+				}
+			},
+			expectError:    true,
+			expectResult:   reconcile.Result{},
+			postTestChecks: func(t *testing.T, cl client.Client) {},
+		},
+		{
+			name: "reconcile_job_lookup_error_non_notfound",
+			setupEnv: func(t *testing.T) {
+				os.Setenv("OPERATOR_IMAGE", "img")
+			},
+			setupObjects: func() []client.Object {
+				mg := &mustgatherv1alpha1.MustGather{
+					ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: "ns", Finalizers: []string{mustGatherFinalizer}},
+					Spec: mustgatherv1alpha1.MustGatherSpec{
+						ServiceAccountRef: corev1.LocalObjectReference{Name: "default"},
+						UploadTarget: &mustgatherv1alpha1.UploadTargetSpec{
+							Type: mustgatherv1alpha1.UploadTypeSFTP,
+							SFTP: &mustgatherv1alpha1.SFTPSpec{
+								CaseID:                         "12345678",
+								CaseManagementAccountSecretRef: corev1.LocalObjectReference{Name: "secret"},
+							},
+						},
+					},
+				}
+				userSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "secret", Namespace: "ns"}}
+				cv := &configv1.ClusterVersion{
+					ObjectMeta: metav1.ObjectMeta{Name: "version"},
+					Status: configv1.ClusterVersionStatus{
+						History: []configv1.UpdateHistory{{State: "Completed", Version: "1.2.3"}},
+					},
+				}
+				return []client.Object{mg, userSecret, cv}
+			},
+			interceptors: func() interceptClient {
+				return interceptClient{
+					onGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+						// Fail the initial job lookup with a non-NotFound error
+						if _, ok := obj.(*batchv1.Job); ok && key.Name == "example-mustgather" && key.Namespace == "ns" {
+							return errors.New("API server error - unable to look up job")
+						}
+						return nil
+					},
+				}
+			},
+			expectError:    true,
+			expectResult:   reconcile.Result{},
+			postTestChecks: func(t *testing.T, cl client.Client) {},
+		},
+		{
+			name: "reconcile_job_not_found_get_secret_returns_non_not_found_error_in_operator_ns",
+			setupEnv: func(t *testing.T) {
+				t.Setenv("OSDK_FORCE_RUN_MODE", "local")
+				os.Setenv("OPERATOR_IMAGE", "img")
+			},
+			setupObjects: func() []client.Object {
+				mg := &mustgatherv1alpha1.MustGather{
+					ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: "ns", Finalizers: []string{mustGatherFinalizer}},
+					Spec: mustgatherv1alpha1.MustGatherSpec{
+						ServiceAccountRef: corev1.LocalObjectReference{Name: "default"},
+						UploadTarget: &mustgatherv1alpha1.UploadTargetSpec{
+							Type: mustgatherv1alpha1.UploadTypeSFTP,
+							SFTP: &mustgatherv1alpha1.SFTPSpec{
+								CaseID:                         "12345678",
+								CaseManagementAccountSecretRef: corev1.LocalObjectReference{Name: "secret"},
+							},
+						},
+					},
+				}
+				userSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "secret", Namespace: "ns"}}
+				cv := &configv1.ClusterVersion{
+					ObjectMeta: metav1.ObjectMeta{Name: "version"},
+					Status: configv1.ClusterVersionStatus{
+						History: []configv1.UpdateHistory{{State: "Completed", Version: "1.2.3"}},
+					},
+				}
+				return []client.Object{mg, userSecret, cv}
+			},
+			interceptors: func() interceptClient {
+				return interceptClient{
+					onGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+						// Return non-NotFound error when getting secret in operator namespace
+						if _, ok := obj.(*corev1.Secret); ok && key.Namespace == defaultMustGatherNamespace && key.Name == "secret" {
+							return errors.New("API server unavailable - failed to get operator secret")
+						}
+						return nil
+					},
+				}
+			},
+			expectError:    true,
+			expectResult:   reconcile.Result{},
+			postTestChecks: func(t *testing.T, cl client.Client) {},
+		},
+		{
+			name: "reconcile_job_not_found_operator_secret_create_fails",
+			setupEnv: func(t *testing.T) {
+				t.Setenv("OSDK_FORCE_RUN_MODE", "local")
+				os.Setenv("OPERATOR_IMAGE", "img")
+			},
+			setupObjects: func() []client.Object {
+				mg := &mustgatherv1alpha1.MustGather{
+					ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: "ns", Finalizers: []string{mustGatherFinalizer}},
+					Spec: mustgatherv1alpha1.MustGatherSpec{
+						ServiceAccountRef: corev1.LocalObjectReference{Name: "default"},
+						UploadTarget: &mustgatherv1alpha1.UploadTargetSpec{
+							Type: mustgatherv1alpha1.UploadTypeSFTP,
+							SFTP: &mustgatherv1alpha1.SFTPSpec{
+								CaseID:                         "12345678",
+								CaseManagementAccountSecretRef: corev1.LocalObjectReference{Name: "secret"},
+							},
+						},
+					},
+				}
+				userSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "secret", Namespace: "ns"}}
+				cv := &configv1.ClusterVersion{
+					ObjectMeta: metav1.ObjectMeta{Name: "version"},
+					Status: configv1.ClusterVersionStatus{
+						History: []configv1.UpdateHistory{{State: "Completed", Version: "1.2.3"}},
+					},
+				}
+				return []client.Object{mg, userSecret, cv}
+			},
+			interceptors: func() interceptClient {
+				return interceptClient{
+					onCreate: func(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+						// Fail secret creation
+						if _, ok := obj.(*corev1.Secret); ok {
+							return errors.New("failed to create secret")
+						}
+						return nil
+					},
+				}
+			},
+			expectError:    true,
+			expectResult:   reconcile.Result{},
+			postTestChecks: func(t *testing.T, cl client.Client) {},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup environment
+			tt.setupEnv(t)
+
+			// Setup scheme
+			s := runtime.NewScheme()
+			_ = corev1.AddToScheme(s)
+			_ = batchv1.AddToScheme(s)
+			_ = mustgatherv1alpha1.AddToScheme(s)
+			_ = configv1.AddToScheme(s)
+
+			// Setup objects and client
+			objects := tt.setupObjects()
+			base := fake.NewClientBuilder().WithScheme(s).WithObjects(objects...).WithStatusSubresource(&mustgatherv1alpha1.MustGather{}).Build()
+
+			// Setup interceptor if needed
+			interceptor := tt.interceptors()
+			var cl client.Client = base
+			if interceptor.onGet != nil || interceptor.onList != nil || interceptor.onDelete != nil || interceptor.onUpdate != nil || interceptor.onCreate != nil || interceptor.status != nil {
+				interceptor.Client = base
+				cl = interceptor
+			}
+
+			// Create reconciler
+			r := &MustGatherReconciler{ReconcilerBase: util.NewReconcilerBase(cl, s, &rest.Config{}, &record.FakeRecorder{}, nil)}
+
+			// Determine request based on test objects
+			var req reconcile.Request
+			for _, obj := range objects {
+				if mgObj, ok := obj.(*mustgatherv1alpha1.MustGather); ok {
+					req = reconcile.Request{NamespacedName: types.NamespacedName{Name: mgObj.Name, Namespace: mgObj.Namespace}}
+					break
+				}
+			}
+			// Default request if no MustGather object found
+			if req.Name == "" {
+				req = reconcile.Request{NamespacedName: types.NamespacedName{Name: "x", Namespace: "y"}}
+			}
+
+			// Execute
+			res, err := r.Reconcile(context.TODO(), req)
+
+			// Assert error expectation
+			if tt.expectError && err == nil {
+				t.Fatalf("expected error but got none")
+			}
+			if !tt.expectError && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			// Assert result expectation
+			if res != tt.expectResult {
+				t.Fatalf("expected result %+v, got %+v", tt.expectResult, res)
+			}
+
+			// Run post-test checks
+			tt.postTestChecks(t, cl)
+		})
+	}
+}
+
+// Helper functions for tests from HEAD branch
 func TestMustGatherController(t *testing.T) {
 	mgObj := createMustGatherObject()
 	secObj := createMustGatherSecretObject()
@@ -37,12 +1098,9 @@ func TestMustGatherController(t *testing.T) {
 		mgObj,
 		secObj,
 	}
-
-	var cfg *rest.Config
-
 	cl, s := generateFakeClient(objs...)
-
 	eventRec := &record.FakeRecorder{}
+	var cfg *rest.Config
 
 	r := MustGatherReconciler{
 		ReconcilerBase: util.NewReconcilerBase(cl, s, cfg, eventRec, nil),
@@ -55,13 +1113,9 @@ func TestMustGatherController(t *testing.T) {
 		},
 	}
 
-	res, err := r.Reconcile(context.TODO(), req)
+	_, err := r.Reconcile(context.TODO(), req)
 	if err != nil {
 		t.Fatalf("reconcile: (%v)", err)
-	}
-
-	if res != (reconcile.Result{}) {
-		t.Error("reconcile did not return an empty Result")
 	}
 }
 
@@ -111,7 +1165,7 @@ func TestMustGatherControllerWithUploadTarget(t *testing.T) {
 				t.Fatalf("reconcile: (%v)", err)
 			}
 
-			job, err := r.getJobFromInstance(tt.mustGather)
+			job, err := r.getJobFromInstance(context.TODO(), tt.mustGather)
 			if err != nil {
 				t.Fatalf("getJobFromInstance : (%v)", err)
 			}
@@ -141,8 +1195,8 @@ func createMustGatherObject() *mustgatherv1alpha1.MustGather {
 			Kind: "MustGather",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-must-gather",
-			Namespace: "must-gather-operator",
+			Name:      "example-mustgather",
+			Namespace: "openshift-must-gather-operator",
 		},
 		Spec: mustgatherv1alpha1.MustGatherSpec{
 			ServiceAccountRef: corev1.LocalObjectReference{
@@ -177,16 +1231,19 @@ func createMustGatherObjectWithoutUploadTarget() *mustgatherv1alpha1.MustGather 
 func createMustGatherSecretObject() *corev1.Secret {
 	return &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       "Secret",
-			APIVersion: corev1.SchemeGroupVersion.String(),
+			Kind: "Secret",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "case-management-creds",
-			Namespace: "must-gather-operator",
-		},
-		Data: map[string][]byte{
-			"username": []byte("somefakeuser"),
-			"password": []byte("somefakepassword"),
+			Namespace: "openshift-must-gather-operator",
 		},
 	}
+}
+
+func generateFakeClient(objs ...runtime.Object) (client.Client, *runtime.Scheme) {
+	s := scheme.Scheme
+	s.AddKnownTypes(mustgatherv1alpha1.GroupVersion, &mustgatherv1alpha1.MustGather{})
+	s.AddKnownTypes(configv1.GroupVersion, &configv1.ClusterVersion{})
+	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
+	return cl, s
 }

--- a/deploy/crds/operator.openshift.io_mustgathers.yaml
+++ b/deploy/crds/operator.openshift.io_mustgathers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.1-0.20250818134112-b624019bbe8d
+    controller-gen.kubebuilder.io/version: v0.16.4
   name: mustgathers.operator.openshift.io
 spec:
   group: operator.openshift.io

--- a/deploy/crds/operator.openshift.io_mustgathers.yaml
+++ b/deploy/crds/operator.openshift.io_mustgathers.yaml
@@ -71,6 +71,12 @@ spec:
                 - httpProxy
                 - httpsProxy
                 type: object
+              retainResourcesOnCompletion:
+                default: false
+                description: |-
+                  A flag to specify if resources (secret, job, pods) should be retained when the MustGather completes.
+                  If set to true, resources will be retained. If false or not set, resources will be deleted (default behavior).
+                type: boolean
               serviceAccountRef:
                 description: |-
                   the service account to use to run the must gather job pod, defaults to default

--- a/examples/mustgather_retain_resources.yaml
+++ b/examples/mustgather_retain_resources.yaml
@@ -1,0 +1,11 @@
+apiVersion: managed.openshift.io/v1alpha1
+kind: MustGather
+metadata:
+  name: example-mustgather-retain-resources
+spec:
+  caseID: '02527285'
+  caseManagementAccountSecretRef:
+    name: case-management-creds
+  serviceAccountRef:
+    name: must-gather-admin
+  retainResourcesOnCompletion: true


### PR DESCRIPTION
This PR implements the change to prevent the immediate deletion of must-gather CR and its associated job upon completion and gives the user visibility into the final status of the operation and the ability to review the logs and resource state before the cleanup process. This behavior will be flag based.

1. `retainResourcesOnCompletion` field should be set to true in the spec for the resources to be retained. Default behavior will be to delete all the resources.
2. MustGather CR will be retained irrespective of the `retainResourcesOnCompletion` field.