### PR TITLE
MG-69: Move to `operator.openshift.io` api group

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -1,6 +1,6 @@
 domain: openshift.io
 layout:
-- go.kubebuilder.io/v3
+- go.kubebuilder.io/v4
 plugins:
   manifests.sdk.operatorframework.io/v2: {}
   scorecard.sdk.operatorframework.io/v2: {}
@@ -12,7 +12,7 @@ resources:
     namespaced: true
   controller: true
   domain: openshift.io
-  group: managed
+  group: operator
   kind: MustGather
   path: github.com/openshift/must-gather-operator/api/v1alpha1
   version: v1alpha1

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Must Gather operator helps collecting must-gather information on a cluster a
 To use the operator, a cluster administrator can create the following MustGather CR:
 
 ```yaml
-apiVersion: managed.openshift.io/v1alpha1
+apiVersion: operator.openshift.io/v1alpha1
 kind: MustGather
 metadata:
   name: example-mustgather-basic
@@ -22,7 +22,7 @@ This request will collect the standard must-gather info and upload it to case `#
 The field `audit` is **false** by default unless explicetely set to **true**.
 This will generate the default collection of audit logs as per [the collection script: gather_audit_logs](https://github.com/openshift/must-gather/blob/master/collection-scripts/gather_audit_logs)
 ```yaml
-apiVersion: managed.openshift.io/v1alpha1
+apiVersion: operator.openshift.io/v1alpha1
 kind: MustGather
 metadata:
   name: example-mustgather-full
@@ -40,7 +40,7 @@ spec:
 The Must Gather operator supports using a proxy. The proxy setting can be specified in the MustGather object. If not specified, the cluster default proxy setting will be used. Here is an example:
 
 ```yaml
-apiVersion: managed.openshift.io/v1alpha1
+apiVersion: operator.openshift.io/v1alpha1
 kind: MustGather
 metadata:
   name: example-mustgather-proxy
@@ -71,7 +71,7 @@ Here are the instructions to install the latest release creating the manifest di
 
 ```shell
 git clone git@github.com:openshift/must-gather-operator.git; cd must-gather-operator
-oc apply -f deploy/crds/managed.openshift.io_mustgathers_crd.yaml
+oc apply -f deploy/crds/operator.openshift.io_mustgathers_crd.yaml
 oc new-project must-gather-operator
 oc -n must-gather-operator apply -f deploy
 ```
@@ -102,7 +102,7 @@ go mod download
 Using the [operator-sdk](https://github.com/operator-framework/operator-sdk), run the operator locally:
 
 ```shell
-oc apply -f deploy/crds/managed.openshift.io_mustgathers_crd.yaml
+oc apply -f deploy/crds/operator.openshift.io_mustgathers_crd.yaml
 oc new-project must-gather-operator
 export DEFAULT_MUST_GATHER_IMAGE='quay.io/openshift/origin-must-gather:latest'
 OPERATOR_NAME=must-gather-operator operator-sdk run --verbose --local --namespace ''

--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1alpha1 contains API Schema definitions for the managed v1alpha1 API group
+// Package v1alpha1 contains API Schema definitions for the operator v1alpha1 API group
 //+kubebuilder:object:generate=true
-//+groupName=managed.openshift.io
+//+groupName=operator.openshift.io
 package v1alpha1
 
 import (
@@ -26,7 +26,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "managed.openshift.io", Version: "v1alpha1"}
+	GroupVersion = schema.GroupVersion{Group: "operator.openshift.io", Version: "v1alpha1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -26,14 +26,16 @@ func schema_openshift_must_gather_operator_api_v1alpha1_ProxySpec(ref common.Ref
 				Properties: map[string]spec.Schema{
 					"httpProxy": {
 						SchemaProps: spec.SchemaProps{
-							Description: "httpProxy is the URL of the proxy for HTTP requests.  Empty means unset and will not result in an env var.",
+							Description: "httpProxy is the URL of the proxy for HTTP requests.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"httpsProxy": {
 						SchemaProps: spec.SchemaProps{
-							Description: "httpsProxy is the URL of the proxy for HTTPS requests.  Empty means unset and will not result in an env var.",
+							Description: "httpsProxy is the URL of the proxy for HTTPS requests.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -46,6 +48,7 @@ func schema_openshift_must_gather_operator_api_v1alpha1_ProxySpec(ref common.Ref
 						},
 					},
 				},
+				Required: []string{"httpProxy", "httpsProxy"},
 			},
 		},
 	}

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -7,7 +7,7 @@ COPY . /go/src/github.com/openshift/must-gather-operator
 
 RUN make go-build
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1754584681
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1758184547
 
 RUN microdnf install -y tar gzip openssh-clients wget shadow-utils procps sshpass nc && \
     microdnf clean all

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1754456323
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1758184547
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/bundle/manifests/tech-preview/operator.openshift.io_mustgathers.yaml
+++ b/bundle/manifests/tech-preview/operator.openshift.io_mustgathers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.1-0.20250818134112-b624019bbe8d
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: mustgathers.operator.openshift.io
 spec:
   group: operator.openshift.io

--- a/bundle/manifests/tech-preview/operator.openshift.io_mustgathers.yaml
+++ b/bundle/manifests/tech-preview/operator.openshift.io_mustgathers.yaml
@@ -4,9 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.1-0.20250818134112-b624019bbe8d
-  name: mustgathers.managed.openshift.io
+  name: mustgathers.operator.openshift.io
 spec:
-  group: managed.openshift.io
+  group: operator.openshift.io
   names:
     kind: MustGather
     listKind: MustGatherList

--- a/bundle/manifests/tech-preview/support-log-gather-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/tech-preview/support-log-gather-operator.clusterserviceversion.yaml
@@ -148,7 +148,7 @@ spec:
           verbs:
           - get
         - apiGroups:
-          - managed.openshift.io
+          - operator.openshift.io
           resources:
           - mustgathers
           verbs:
@@ -160,7 +160,7 @@ spec:
           - update
           - watch
         - apiGroups:
-          - managed.openshift.io
+          - operator.openshift.io
           resources:
           - mustgathers/status
           verbs:
@@ -243,8 +243,8 @@ spec:
   customresourcedefinitions:
     owned:
     - displayName: Must Gather
-      group: managed.openshift.io
+      group: operator.openshift.io
       kind: MustGather
-      name: mustgathers.managed.openshift.io
+      name: mustgathers.operator.openshift.io
       description: Represents a must-gather diagnostic collection job
       version: v1alpha1

--- a/controllers/mustgather/mustgather_controller.go
+++ b/controllers/mustgather/mustgather_controller.go
@@ -59,11 +59,11 @@ type MustGatherReconciler struct {
 	util.ReconcilerBase
 }
 
-const mustGatherFinalizer = "finalizer.mustgathers.managed.openshift.io"
+const mustGatherFinalizer = "finalizer.mustgathers.operator.openshift.io"
 
-//+kubebuilder:rbac:groups=managed.openshift.io,resources=mustgathers,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=managed.openshift.io,resources=mustgathers/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=managed.openshift.io,resources=mustgathers/finalizers,verbs=update
+//+kubebuilder:rbac:groups=operator.openshift.io,resources=mustgathers,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=operator.openshift.io,resources=mustgathers/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=operator.openshift.io,resources=mustgathers/finalizers,verbs=update
 //+kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions,verbs=get;list;watch
 //+kubebuilder:rbac:groups=batch,resources=jobs;jobs/finalizers,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;create

--- a/deploy/02_must-gather-operator.ClusterRole.yaml
+++ b/deploy/02_must-gather-operator.ClusterRole.yaml
@@ -55,7 +55,7 @@ rules:
       - "update"
   # operator business logic
   - apiGroups:
-      - managed.openshift.io
+      - operator.openshift.io
     resources:
       - "mustgathers"
       - mustgathers/finalizers

--- a/deploy/crds/operator.openshift.io_mustgathers.yaml
+++ b/deploy/crds/operator.openshift.io_mustgathers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: mustgathers.operator.openshift.io
 spec:
   group: operator.openshift.io

--- a/deploy/crds/operator.openshift.io_mustgathers.yaml
+++ b/deploy/crds/operator.openshift.io_mustgathers.yaml
@@ -4,9 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.4
-  name: mustgathers.managed.openshift.io
+  name: mustgathers.operator.openshift.io
 spec:
-  group: managed.openshift.io
+  group: operator.openshift.io
   names:
     kind: MustGather
     listKind: MustGatherList

--- a/deploy/crds/operator.openshift.io_mustgathers.yaml
+++ b/deploy/crds/operator.openshift.io_mustgathers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.16.4
   name: mustgathers.operator.openshift.io
 spec:
   group: operator.openshift.io
@@ -82,18 +82,19 @@ spec:
                   left empty it will default to the cluster-level proxy configuration.
                 properties:
                   httpProxy:
-                    description: httpProxy is the URL of the proxy for HTTP requests.  Empty
-                      means unset and will not result in an env var.
+                    description: httpProxy is the URL of the proxy for HTTP requests.
                     type: string
                   httpsProxy:
-                    description: httpsProxy is the URL of the proxy for HTTPS requests.  Empty
-                      means unset and will not result in an env var.
+                    description: httpsProxy is the URL of the proxy for HTTPS requests.
                     type: string
                   noProxy:
                     description: noProxy is the list of domains for which the proxy
                       should not be used.  Empty means unset and will not result in
                       an env var.
                     type: string
+                required:
+                - httpProxy
+                - httpsProxy
                 type: object
               serviceAccountRef:
                 description: |-

--- a/examples/mustgather_basic.yaml
+++ b/examples/mustgather_basic.yaml
@@ -1,4 +1,4 @@
-apiVersion: managed.openshift.io/v1alpha1
+apiVersion: operator.openshift.io/v1alpha1
 kind: MustGather
 metadata:
   name: example-mustgather

--- a/examples/mustgather_full.yaml
+++ b/examples/mustgather_full.yaml
@@ -1,4 +1,4 @@
-apiVersion: managed.openshift.io/v1alpha1
+apiVersion: operator.openshift.io/v1alpha1
 kind: MustGather
 metadata:
   name: full-mustgather

--- a/examples/mustgather_non_internal_user.yaml
+++ b/examples/mustgather_non_internal_user.yaml
@@ -1,4 +1,4 @@
-apiVersion: managed.openshift.io/v1alpha1
+apiVersion: operator.openshift.io/v1alpha1
 kind: MustGather
 metadata:
   name: example-mustgather

--- a/examples/mustgather_proxy.yaml
+++ b/examples/mustgather_proxy.yaml
@@ -1,4 +1,4 @@
-apiVersion: managed.openshift.io/v1alpha1
+apiVersion: operator.openshift.io/v1alpha1
 kind: MustGather
 metadata:
   name: example-mustgather-proxy

--- a/examples/mustgather_timeout.yaml
+++ b/examples/mustgather_timeout.yaml
@@ -1,4 +1,4 @@
-apiVersion: managed.openshift.io/v1alpha1
+apiVersion: operator.openshift.io/v1alpha1
 kind: MustGather
 metadata:
   name: example-mustgather

--- a/test/must-gather.yaml
+++ b/test/must-gather.yaml
@@ -1,4 +1,4 @@
-apiVersion: managed.openshift.io/v1alpha1
+apiVersion: operator.openshift.io/v1alpha1
 kind: MustGather
 metadata:
   name: example-mustgather


### PR DESCRIPTION
The CRDs are present in the `managed.openshift.io` api group, which could have some unintended side-effects when installing the operator on a regular OpenShift cluster that is not OSD or from a managed fleet.

eg. side effect: https://github.com/stolostron/multicloud-operators-foundation/blob/4b57f6986b2a9e7e5e09bdd380ee3ea4b21a8bae/pkg/klusterlet/clusterinfo/clusterinfo_controller.go#L472-L491

Slack thread, xref: https://redhat-internal.slack.com/archives/C091D81AQV9/p1753947183942009