### PR TITLE
Updating OWNERS file to include SRE again

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,12 +1,24 @@
 reviewers:
+- bng0y
+- devppratik
+- dustman9000
+- srep-functional-team-hulk
 - shivprakashmuley
 - swghosh
 - TrilokGeer
 approvers:
+- bng0y
+- devppratik
+- dustman9000
+- mmazur
+- srep-functional-leads
+- srep-team-leads
 - shivprakashmuley
 - swghosh
 - TrilokGeer
 maintainers:
+- bng0y
+- dustman9000
 - shivprakashmuley
 - swghosh
 - TrilokGeer


### PR DESCRIPTION
Updating OWNERS file to include SRE as well as before in addition to new reviewers/approvers.

We will update and evolve this list ahead based on long term plan.

This PR is related to change in PR https://github.com/openshift/must-gather-operator/pull/248 