### PR TITLE
MG-65: add clusterversions permissions

### DIFF
--- a/bundle/manifests/tech-preview/must-gather-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/tech-preview/must-gather-operator.clusterserviceversion.yaml
@@ -168,9 +168,24 @@ spec:
           - patch
           - update
         - apiGroups:
+          - managed.openshift.io
+          resources:
+          - mustgathers/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - clusterversions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - batch
           resources:
           - jobs
+          - jobs/finalizers
           verbs:
           - create
           - delete

--- a/controllers/mustgather/mustgather_controller.go
+++ b/controllers/mustgather/mustgather_controller.go
@@ -64,6 +64,12 @@ const mustGatherFinalizer = "finalizer.mustgathers.managed.openshift.io"
 //+kubebuilder:rbac:groups=managed.openshift.io,resources=mustgathers,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=managed.openshift.io,resources=mustgathers/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=managed.openshift.io,resources=mustgathers/finalizers,verbs=update
+//+kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions,verbs=get;list;watch
+//+kubebuilder:rbac:groups=batch,resources=jobs;jobs/finalizers,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;create
+//+kubebuilder:rbac:groups=apps,resources=deployments;daemonsets;replicasets;statefulsets,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=apps,resources=deployments/finalizers,verbs=update
+//+kubebuilder:rbac:groups="",resources=pods;services;services/finalizers;endpoints;persistentvolumeclaims;events;configmaps;secrets,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
The ClusterRole defined in the must-gather-operator CSV file is missing the get, list, and watch permissions for the clusterversions resource in the config.openshift.io API group.

Add a clusterversions permission rule
Add a new rule block to the existing rules under clusterPermissions to grant the must-gather-operator ServiceAccount get, list, and watch permissions on the clusterversions resource.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Expanded operator permissions to manage jobs (including finalizers), workloads (deployments, daemonsets, statefulsets, replicasets), and core resources (pods, services, PVCs, events, configmaps, secrets).
  - Added read access to cluster version information for better compatibility handling.
  - Enabled creation of ServiceMonitors to improve observability and metrics integration.
  - Improved handling of resource finalization for smoother cleanups and upgrades.

- Chores
  - Aligned RBAC rules in manifests with controller annotations to ensure consistent, up-to-date permissions across releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->