### PR TITLE
MG-79: Corrected proxyConfig fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ spec:
   serviceAccountRef:
     name: must-gather-admin
   proxyConfig:
-    http_proxy: http://myproxy
-    https_proxy: https://my_http_proxy
-    no_proxy: master-api
+    httpProxy: http://myproxy
+    httpsProxy: https://my_http_proxy
+    noProxy: master-api
 ```
 
 ## Garbage collection

--- a/examples/mustgather_proxy.yaml
+++ b/examples/mustgather_proxy.yaml
@@ -9,6 +9,6 @@ spec:
   serviceAccountRef:
     name: must-gather-admin
   proxyConfig:
-    http_proxy: http://myproxy
-    https_proxy: https://my_http_proxy
-    no_proxy: master-api
+    httpProxy: http://myproxy
+    httpsProxy: https://my_http_proxy
+    noProxy: master-api


### PR DESCRIPTION
Fixes a typo in README's example to use camelCase proxy keys in `proxyConfig (httpProxy, httpsProxy, noProxy)` to match the correct CRD schema.