### PR TITLE
MG-87: Update package name to support-log-gather-operator

### DIFF
--- a/bundle/bundle.Dockerfile
+++ b/bundle/bundle.Dockerfile
@@ -2,7 +2,7 @@ FROM scratch
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
-LABEL operators.operatorframework.io.bundle.package.v1=must-gather-operator
+LABEL operators.operatorframework.io.bundle.package.v1=support-log-gather-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=tech-preview
 LABEL operators.operatorframework.io.bundle.channel.default.v1=tech-preview
 COPY manifests/tech-preview/*.yaml /manifests/

--- a/bundle/manifests/must-gather-operator.package.yaml
+++ b/bundle/manifests/must-gather-operator.package.yaml
@@ -1,4 +1,4 @@
-packageName: must-gather-operator
+packageName: support-log-gather-operator
 channels:
 - name: tech-preview
   currentCSV: support-log-gather-operator.v4.20.0

--- a/bundle/manifests/tech-preview/image-references
+++ b/bundle/manifests/tech-preview/image-references
@@ -3,7 +3,7 @@ kind: ImageStream
 apiVersion: image.openshift.io/v1
 spec:
   tags:
-  - name: must-gather-operator
+  - name: support-log-gather-operator
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-support-log-gather-operator:latest

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -4,4 +4,4 @@ annotations:
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/
-  operators.operatorframework.io.bundle.package.v1: must-gather-operator 
+  operators.operatorframework.io.bundle.package.v1: support-log-gather-operator


### PR DESCRIPTION
- Update OLM packageName to "support-log-gather-operator" to avoid conflicts with (old) community operator package name "must-gather-operator".

- Plausible fix for ART build failures: `ERROR Failed to rebase ose-support-log-gather-operator: Unable to find must-gather-operator in image-references data for ose-support-log-gather-operator`, xref: https://redhat-internal.slack.com/archives/CB95J6R4N/p1757326887748429?thread_ts=1757060177.392799&cid=CB95J6R4N