### PR TITLE
OCPBUGS-63468: set api `internalUser` to false by default

### DIFF
--- a/api/v1alpha1/mustgather_types.go
+++ b/api/v1alpha1/mustgather_types.go
@@ -72,7 +72,7 @@ type SFTPSpec struct {
 
 	// A flag to specify if the upload user provided in the caseManagementAccountSecret is a RH internal user.
 	// See documentation for further information.
-	// +kubebuilder:default:=true
+	// +kubebuilder:default:=false
 	InternalUser bool `json:"internalUser,omitempty"`
 
 	// host specifies the SFTP server hostname.

--- a/bundle/manifests/tech-preview/operator.openshift.io_mustgathers.yaml
+++ b/bundle/manifests/tech-preview/operator.openshift.io_mustgathers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.1-0.20250818134112-b624019bbe8d
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: mustgathers.operator.openshift.io
 spec:
   group: operator.openshift.io
@@ -128,7 +128,7 @@ spec:
                           The host name of the SFTP server
                         type: string
                       internalUser:
-                        default: true
+                        default: false
                         description: |-
                           A flag to specify if the upload user provided in the caseManagementAccountSecret is a RH internal user.
                           See documentation for further information.

--- a/deploy/crds/operator.openshift.io_mustgathers.yaml
+++ b/deploy/crds/operator.openshift.io_mustgathers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: mustgathers.operator.openshift.io
 spec:
   group: operator.openshift.io
@@ -128,7 +128,7 @@ spec:
                           The host name of the SFTP server
                         type: string
                       internalUser:
-                        default: true
+                        default: false
                         description: |-
                           A flag to specify if the upload user provided in the caseManagementAccountSecret is a RH internal user.
                           See documentation for further information.


### PR DESCRIPTION
- The field `internalUser` is marked as `true` by default, so in the absence of a user proving this value in the CR create/update, today we assert true while we should only default to false ideally.

An internal user credentials from a user within Red Hat trying to access sftp.access.redhat.com,
users outside Red Hat are `internalUser=false`.

/assign @rausingh-rh  