### PR TITLE
MG-87: update operator name in ClusterServiceVersion to `support-log-gather`

### DIFF
--- a/bundle/manifests/tech-preview/support-log-gather-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/tech-preview/support-log-gather-operator.clusterserviceversion.yaml
@@ -31,22 +31,15 @@ metadata:
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
 spec:
-  displayName: Must Gather Operator
+  displayName: support log gather
   description: |
-    The Must Gather Operator helps collecting must-gather diagnostic information from OpenShift clusters.
-    
-    ## About Must Gather Operator
-    
-    The Must Gather Operator enables Customer Experience and Engagement (CEE) teams to collect diagnostic 
-    information (must-gathers) from OpenShift Dedicated v4 clusters. This operator provides a custom 
-    resource definition (CRD) that allows authorized users to create must-gather jobs in a controlled manner.
+    An operator that collects logs in Red Hat OpenShift and sends them to Red Hat Support for troubleshooting.
     
     ## Features
     
     * Automated must-gather collection
-    * Support for different must-gather images
-    * Configurable resource limits
     * Secure collection and storage
+
   icon:
     - base64data: PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxOTIgMTQ1Ij48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UwMDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlJlZEhhdC1Mb2dvLUhhdC1Db2xvcjwvdGl0bGU+PHBhdGggZD0iTTE1Ny43Nyw2Mi42MWExNCwxNCwwLDAsMSwuMzEsMy40MmMwLDE0Ljg4LTE4LjEsMTcuNDYtMzAuNjEsMTcuNDZDNzguODMsODMuNDksNDIuNTMsNTMuMjYsNDIuNTMsNDRhNi40Myw2LjQzLDAsMCwxLC4yMi0xLjk0bC0zLjY2LDkuMDZhMTguNDUsMTguNDUsMCwwLDAtMS41MSw3LjMzYzAsMTguMTEsNDEsNDUuNDgsODcuNzQsNDUuNDgsMjAuNjksMCwzNi40My03Ljc2LDM2LjQzLTIxLjc3LDAtMS4wOCwwLTEuOTQtMS43My0xMC4xM1oiLz48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik0xMjcuNDcsODMuNDljMTIuNTEsMCwzMC42MS0yLjU4LDMwLjYxLTE3LjQ2YTE0LDE0LDAsMCwwLS4zMS0zLjQybC03LjQ1LTMyLjM2Yy0xLjcyLTcuMTItMy4yMy0xMC4zNS0xNS43My0xNi42QzEyNC44OSw4LjY5LDEwMy43Ni41LDk3LjUxLjUsOTEuNjkuNSw5MCw4LDgzLjA2LDhjLTYuNjgsMC0xMS42NC01LjYtMTcuODktNS42LTYsMC05LjkxLDQuMDktMTIuOTMsMTIuNSwwLDAtOC40MSwyMy43Mi05LjQ5LDI3LjE2QTYuNDMsNi40MywwLDAsMCw0Mi41Myw0NGMwLDkuMjIsMzYuMywzOS40NSw4NC45NCwzOS40NU0xNjAsNzIuMDdjMS43Myw4LjE5LDEuNzMsOS4wNSwxLjczLDEwLjEzLDAsMTQtMTUuNzQsMjEuNzctMzYuNDMsMjEuNzdDNzguNTQsMTA0LDM3LjU4LDc2LjYsMzcuNTgsNTguNDlhMTguNDUsMTguNDUsMCwwLDEsMS41MS03LjMzQzIyLjI3LDUyLC41LDU1LC41LDc0LjIyYzAsMzEuNDgsNzQuNTksNzAuMjgsMTMzLjY1LDcwLjI4LDQ1LjI4LDAsNTYuNy0yMC40OCw1Ni43LTM2LjY1LDAtMTIuNzItMTEtMjcuMTYtMzAuODMtMzUuNzgiLz48L3N2Zz4=
       mediatype: image/svg+xml

--- a/bundle/manifests/tech-preview/support-log-gather-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/tech-preview/support-log-gather-operator.clusterserviceversion.yaml
@@ -13,7 +13,7 @@ metadata:
     support: Red Hat
     repository: https://github.com/openshift/must-gather-operator
     olm.skipRange: ">=4.20.0-0 <4.20.0"
-    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/disconnected: "false"
     features.operators.openshift.io/fips-compliant: "true"
     features.operators.openshift.io/proxy-aware: "true"
     features.operators.openshift.io/tls-profiles: "false"


### PR DESCRIPTION
Following our [OPL](https://docs.google.com/spreadsheets/d/1DLS_lS3VKidgZIvcLmLp9BoiqptkvqHWfe1D5FD2kfk/edit?gid=1375785039#gid=1375785039) updated the name in the bundle to avoid shipping with an incorrect name viz.

<img width="3080" height="1690" alt="Screenshot 2025-09-11 at 8 46 12 PM (1)" src="https://github.com/user-attachments/assets/5d474d88-5dac-4313-a75e-1c8abebeeec8" />