### PR TITLE
OCPBUGS-63243: Remove hardcoded dependency for operator namespace

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -4,9 +4,6 @@ const (
 	// OperatorName is the name of this operator
 	OperatorName string = "must-gather-operator"
 
-	// OperatorNamespace
-	OperatorNamespace string = "must-gather-operator"
-
 	// MGO is being distributed as part of RVMO now, so use skiprange
 	EnableOLMSkipRange string = "true"
 )

--- a/controllers/mustgather/mustgather_controller_test.go
+++ b/controllers/mustgather/mustgather_controller_test.go
@@ -489,13 +489,13 @@ func TestReconcile(t *testing.T) {
 			postTestChecks: func(t *testing.T, cl client.Client) {
 				// Verify secret was created in operator namespace
 				operatorSecret := &corev1.Secret{}
-				if err := cl.Get(context.TODO(), types.NamespacedName{Namespace: defaultMustGatherNamespace, Name: "secret"}, operatorSecret); err != nil {
+				if err := cl.Get(context.TODO(), types.NamespacedName{Namespace: DefaultMustGatherNamespace, Name: "secret"}, operatorSecret); err != nil {
 					t.Fatalf("expected secret to be created in operator namespace, got error: %v", err)
 				}
 
 				// Verify job was created
 				job := &batchv1.Job{}
-				if err := cl.Get(context.TODO(), types.NamespacedName{Namespace: defaultMustGatherNamespace, Name: "example-mustgather"}, job); err != nil {
+				if err := cl.Get(context.TODO(), types.NamespacedName{Namespace: DefaultMustGatherNamespace, Name: "example-mustgather"}, job); err != nil {
 					t.Fatalf("expected job to be created, got error: %v", err)
 				}
 			},
@@ -969,7 +969,7 @@ func TestReconcile(t *testing.T) {
 				return interceptClient{
 					onGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 						// Return non-NotFound error when getting secret in operator namespace
-						if _, ok := obj.(*corev1.Secret); ok && key.Namespace == defaultMustGatherNamespace && key.Name == "secret" {
+						if _, ok := obj.(*corev1.Secret); ok && key.Namespace == DefaultMustGatherNamespace && key.Name == "secret" {
 							return errors.New("API server unavailable - failed to get operator secret")
 						}
 						return nil

--- a/pkg/k8sutil/k8sutil.go
+++ b/pkg/k8sutil/k8sutil.go
@@ -23,6 +23,10 @@ const (
 	// OperatorNameEnvVar is the constant for env variable OPERATOR_NAME
 	// which is the name of the current operator
 	OperatorNameEnvVar = "OPERATOR_NAME"
+
+	// OperatorNamespaceEnvVar is the constant for env variable
+	// OPERATOR_NAMESPACE, which indicates the namespace of the operator
+	OperatorNamespaceEnvVar = "OPERATOR_NAMESPACE"
 )
 
 // ErrNoNamespace indicates that a namespace could not be found for the current
@@ -39,6 +43,12 @@ func isRunModeLocal() bool {
 
 // GetOperatorNamespace returns the namespace the operator should be running in.
 func GetOperatorNamespace() (string, error) {
+	// OPERATOR_NAMESPACE has highest priority
+	operatorNamespace, found := os.LookupEnv(OperatorNamespaceEnvVar)
+	if found {
+		return operatorNamespace, nil
+	}
+
 	if isRunModeLocal() {
 		return "", ErrRunLocal
 	}


### PR DESCRIPTION
Fixes OCPBUGS-63243,

* "must-gather-operator" namespace may or may not be present on the cluster depending upon installation type
* this implementation will fall back to "default" namespace when OSDK_FORCE_RUN_MODE=local and OPERATOR_NAMESPACE env var value is unset
    * terminates operator process if `OSDK_FORCE_RUN_MODE != local` and namespace was unable to be found from `"/var/run/secrets/kubernetes.io/serviceaccount/namespace"`