### PR TITLE
OCPBUGS-73751:  Add ServiceAccount validation to MustGather controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ kind: MustGather
 metadata:
   name: example-mustgather-basic
 spec:
-  serviceAccountRef:
-    name: must-gather-admin
+  serviceAccountName: must-gather-admin
   uploadTarget:
     type: SFTP
     sftp:
@@ -30,8 +29,7 @@ kind: MustGather
 metadata:
   name: example-mustgather-full
 spec:
-  serviceAccountRef:
-    name: must-gather-admin
+  serviceAccountName: must-gather-admin
   uploadTarget:
     type: SFTP
     sftp:

--- a/bundle/manifests/tech-preview/support-log-gather-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/tech-preview/support-log-gather-operator.clusterserviceversion.yaml
@@ -98,6 +98,14 @@ spec:
           - update
           - watch
         - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - apps
           resources:
           - deployments

--- a/controllers/mustgather/constant.go
+++ b/controllers/mustgather/constant.go
@@ -2,6 +2,9 @@ package mustgather
 
 // Constants defining the supported transfer protocols and validation types
 const (
+	// ValidationServiceAccount represents the validation type for Service account
+	ValidationServiceAccount = "Service Account"
+  
 	// ProtocolSFTP represents the SFTP (SSH File Transfer Protocol)
 	ProtocolSFTP = "SFTP"
 

--- a/deploy/02_must-gather-operator.ClusterRole.yaml
+++ b/deploy/02_must-gather-operator.ClusterRole.yaml
@@ -85,6 +85,14 @@ rules:
       - list
       - watch
   - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - "config.openshift.io"
     resources:
       - proxies

--- a/examples/mustgather_basic.yaml
+++ b/examples/mustgather_basic.yaml
@@ -3,11 +3,11 @@ kind: MustGather
 metadata:
   name: example-mustgather
 spec:
-  serviceAccountRef:
-    name: must-gather-admin
+  serviceAccountName: must-gather-admin
   uploadTarget:
     type: SFTP
     sftp:
       caseID: '02527285'
       caseManagementAccountSecretRef:
         name: case-management-creds
+      internalUser: true

--- a/examples/mustgather_full.yaml
+++ b/examples/mustgather_full.yaml
@@ -3,8 +3,7 @@ kind: MustGather
 metadata:
   name: full-mustgather
 spec:
-  serviceAccountRef:
-    name: must-gather-admin
+  serviceAccountName: must-gather-admin
   uploadTarget:
     type: SFTP
     sftp:

--- a/examples/mustgather_non_internal_user.yaml
+++ b/examples/mustgather_non_internal_user.yaml
@@ -3,8 +3,7 @@ kind: MustGather
 metadata:
   name: example-mustgather
 spec:
-  serviceAccountRef:
-    name: must-gather-admin
+  serviceAccountName: must-gather-admin
   uploadTarget:
     type: SFTP
     sftp:

--- a/examples/mustgather_retain_resources.yaml
+++ b/examples/mustgather_retain_resources.yaml
@@ -3,8 +3,7 @@ kind: MustGather
 metadata:
   name: example-mustgather-retain-resources
 spec:
-  serviceAccountRef:
-    name: must-gather-admin
+  serviceAccountName: must-gather-admin
   uploadTarget:
     type: SFTP
     sftp:

--- a/examples/mustgather_timeout.yaml
+++ b/examples/mustgather_timeout.yaml
@@ -3,8 +3,7 @@ kind: MustGather
 metadata:
   name: example-mustgather
 spec:
-  serviceAccountRef:
-    name: must-gather-admin
+  serviceAccountName: must-gather-admin
   uploadTarget:
     type: SFTP
     sftp:


### PR DESCRIPTION
## Problem Statement
Jira ticket - https://issues.redhat.com/browse/OCPBUGS-73751
When a MustGather custom resource is created with a non-existent `ServiceAccount`, the controller creates a Job that remains stuck in pending state indefinitely. This wastes cluster resources and provides poor user experience as there's no clear error message indicating why the Job cannot proceed.

Additionally, when the `ServiceAccountName` field is left empty, the Kubernetes Job will implicitly use the `default` ServiceAccount. However, if someone has deleted the `default` ServiceAccount in a namespace, the same issue occurs.

## Solution

This PR implements **pre-flight ServiceAccount validation** in the MustGather controller before creating the Job. The controller now:

1. **Validates ServiceAccount existence** before creating the Job
2. **Defaults to "default"** when `ServiceAccountName` is empty
3. **Provides clear error messages** in the MustGather status when validation fails
4. **Distinguishes between transient and permanent errors** for proper retry behavior

### Implementation Details

#### Controller Changes ([mustgather_controller.go](file:///home/nkumari/GolandProjects/must-gather-operator-neha/controllers/mustgather/mustgather_controller.go#L160-L181))

Added ServiceAccount validation logic at lines 160-181:
- Checks if the Job already exists before validation (avoid redundant checks)
- Determines the ServiceAccount name to validate (uses "default" if empty)
- Queries the Kubernetes API for the ServiceAccount
- Returns a descriptive error via `ManageError` if not found
- Requeues for transient API errors

#### Error Handling

Two types of errors are handled differently:
- **NotFound errors**: Permanent error - calls `ManageError` which updates the MustGather status with a clear message
- **Transient errors**: Temporary API failure - returns `reconcile.Result{Requeue: true}` to retry

#### RBAC Permissions ([mustgather_controller.go](file:///home/nkumari/GolandProjects/must-gather-operator-neha/controllers/mustgather/mustgather_controller.go#L70-L71))

Added ServiceAccount read permissions:
```go
//+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch
```

### Test Coverage

Comprehensive test coverage added in [mustgather_controller_test.go](file:///home/nkumari/GolandProjects/must-gather-operator-neha/controllers/mustgather/mustgather_controller_test.go):

1. **Non-existent SA specified** (lines 494-528): Verifies error is reported when explicitly specified SA doesn't exist
2. **Empty SA name with default existing** (lines 530-568): Verifies Job is created when default SA exists
3. **Empty SA name with default missing** (lines 570-610): Verifies error when default SA is missing
4. **Transient API errors** (lines 612-645): Verifies requeue behavior for temporary failures
5. **Successful Job creation** (lines 434-493): Verifies existing success paths still work

All tests verify that:
- Jobs are **not** created when validation fails
- MustGather status is updated with error conditions
- Proper reconciliation results are returned

## Benefits

### User Experience
- **Clear error messages**: Users immediately see why their MustGather is failing
- **No wasted resources**: Jobs are not created if they cannot run
- **Faster feedback**: No need to wait for Job timeout or manually inspect pod events

### Reliability
- **Prevents resource waste**: Avoids creating Jobs that will never succeed
- **Better observability**: Status clearly indicates configuration issues
- **Proper retry logic**: Transient errors are retried, permanent errors are reported

## Backward Compatibility

✅ **Fully backward compatible**

- Existing MustGathers with valid ServiceAccounts continue to work unchanged
- Only adds validation - does not modify existing behavior for valid configurations
- RBAC changes are additive (read-only permissions)