### PR TITLE
OCPBUGS-64626: fix the files in pvc getting overwritten on each MG run

### DIFF
--- a/controllers/mustgather/constant.go
+++ b/controllers/mustgather/constant.go
@@ -4,7 +4,7 @@ package mustgather
 const (
 	// ValidationServiceAccount represents the validation type for Service account
 	ValidationServiceAccount = "Service Account"
-  
+
 	// ProtocolSFTP represents the SFTP (SSH File Transfer Protocol)
 	ProtocolSFTP = "SFTP"
 
@@ -22,4 +22,7 @@ const (
 
 	// DefaultMustGatherImageEnv represents the environment variable for the default must-gather image
 	DefaultMustGatherImageEnv = "DEFAULT_MUST_GATHER_IMAGE"
+
+	// podNameEnvVar is the environment variable name for the current pod's name
+	podNameEnvVar = "POD_NAME"
 )

--- a/controllers/mustgather/template.go
+++ b/controllers/mustgather/template.go
@@ -3,7 +3,9 @@ package mustgather
 import (
 	"fmt"
 	"math"
+	"path"
 	"strconv"
+	"strings"
 
 	"time"
 
@@ -47,7 +49,40 @@ const (
 	// SSH directory and known hosts file
 	sshDir         = "/tmp/must-gather-operator/.ssh"
 	knownHostsFile = "/tmp/must-gather-operator/.ssh/known_hosts"
+
+	// Environment variable specifying the must-gather image
+	defaultMustGatherImageEnv = "DEFAULT_MUST_GATHER_IMAGE"
+
+	// Downward API environment variables used for subPathExpr expansion.
+	podNameEnvVar = "POD_NAME"
 )
+
+func outputSubPathExpr(storage *v1alpha1.Storage) (string, bool) {
+	if storage == nil || storage.Type != v1alpha1.StorageTypePersistentVolume {
+		return "", false
+	}
+
+	base := strings.TrimSpace(storage.PersistentVolume.SubPath)
+	base = strings.Trim(base, "/")
+	if base == "" {
+		return "", false
+	}
+
+	// Use user-provided base path, but isolate each run using the pod name
+	// to avoid overwriting prior collections on the PVC.
+	return path.Join(base, fmt.Sprintf("$(%s)", podNameEnvVar)), true
+}
+
+func podIdentityEnvVars() []corev1.EnvVar {
+	return []corev1.EnvVar{
+		{
+			Name: podNameEnvVar,
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
+			},
+		},
+	}
+}
 
 func getJobTemplate(image string, operatorImage string, mustGather v1alpha1.MustGather, trustedCAConfigMapName string) *batchv1.Job {
 	job := initializeJobTemplate(mustGather.Name, mustGather.Namespace, mustGather.Spec.ServiceAccountName, mustGather.Spec.Storage, trustedCAConfigMapName)
@@ -100,6 +135,7 @@ func getJobTemplate(image string, operatorImage string, mustGather v1alpha1.Must
 					s.CaseID,
 					s.Host,
 					s.InternalUser,
+					mustGather.Spec.Storage,
 					httpProxy,
 					httpsProxy,
 					noProxy,
@@ -205,8 +241,8 @@ func getGatherContainer(image string, audit bool, timeout time.Duration, storage
 		Name:      outputVolumeName,
 	}
 
-	if storage != nil && storage.Type == v1alpha1.StorageTypePersistentVolume && storage.PersistentVolume.SubPath != "" {
-		volumeMount.SubPath = storage.PersistentVolume.SubPath
+	if expr, ok := outputSubPathExpr(storage); ok {
+		volumeMount.SubPathExpr = expr
 	}
 
 	volumeMounts := []corev1.VolumeMount{volumeMount}
@@ -239,6 +275,8 @@ func getGatherContainer(image string, audit bool, timeout time.Duration, storage
 	if len(args) > 0 {
 		container.Args = args
 	}
+	// Provide pod name env var for subPathExpr expansion (used when PVC subPath is set).
+	container.Env = append(container.Env, podIdentityEnvVars()...)
 
 	return container
 }
@@ -248,6 +286,7 @@ func getUploadContainer(
 	caseId string,
 	host string,
 	internalUser bool,
+	storage *v1alpha1.Storage,
 	httpProxy string,
 	httpsProxy string,
 	noProxy string,
@@ -258,11 +297,16 @@ func getUploadContainer(
 	uploadCommandWithSSH := fmt.Sprintf("mkdir -p %s; touch %s; chmod 700 %s; chmod 600 %s; %s",
 		sshDir, knownHostsFile, sshDir, knownHostsFile, uploadCommand)
 
+	outputMount := corev1.VolumeMount{
+		MountPath: volumeMountPath,
+		Name:      outputVolumeName,
+	}
+	if expr, ok := outputSubPathExpr(storage); ok {
+		outputMount.SubPathExpr = expr
+	}
+
 	volumeMounts := []corev1.VolumeMount{
-		{
-			MountPath: volumeMountPath,
-			Name:      outputVolumeName,
-		},
+		outputMount,
 		{
 			MountPath: volumeUploadMountPath,
 			Name:      uploadVolumeName,
@@ -327,6 +371,9 @@ func getUploadContainer(
 			},
 		},
 	}
+
+	// Provide Pod identity env vars for subPathExpr expansion (used when PVC subPath is set).
+	container.Env = append(container.Env, podIdentityEnvVars()...)
 
 	if httpProxy != "" {
 		container.Env = append(container.Env, corev1.EnvVar{Name: uploadEnvHttpProxy, Value: httpProxy})

--- a/controllers/mustgather/template.go
+++ b/controllers/mustgather/template.go
@@ -73,7 +73,7 @@ func outputSubPathExpr(storage *v1alpha1.Storage) (string, bool) {
 	return path.Join(base, fmt.Sprintf("$(%s)", podNameEnvVar)), true
 }
 
-func podIdentityEnvVars() []corev1.EnvVar {
+func podNameEnvVars() []corev1.EnvVar {
 	return []corev1.EnvVar{
 		{
 			Name: podNameEnvVar,
@@ -241,8 +241,9 @@ func getGatherContainer(image string, audit bool, timeout time.Duration, storage
 		Name:      outputVolumeName,
 	}
 
-	if expr, ok := outputSubPathExpr(storage); ok {
-		volumeMount.SubPathExpr = expr
+	subPathExpr, hasSubPathExpr := outputSubPathExpr(storage)
+	if hasSubPathExpr {
+		volumeMount.SubPathExpr = subPathExpr
 	}
 
 	volumeMounts := []corev1.VolumeMount{volumeMount}
@@ -275,8 +276,11 @@ func getGatherContainer(image string, audit bool, timeout time.Duration, storage
 	if len(args) > 0 {
 		container.Args = args
 	}
-	// Provide pod name env var for subPathExpr expansion (used when PVC subPath is set).
-	container.Env = append(container.Env, podIdentityEnvVars()...)
+
+	// Provide pod name env var only when SubPathExpr is used (PVC subPath is set).
+	if hasSubPathExpr {
+		container.Env = append(container.Env, podNameEnvVars()...)
+	}
 
 	return container
 }
@@ -301,8 +305,9 @@ func getUploadContainer(
 		MountPath: volumeMountPath,
 		Name:      outputVolumeName,
 	}
-	if expr, ok := outputSubPathExpr(storage); ok {
-		outputMount.SubPathExpr = expr
+	subPathExpr, hasSubPathExpr := outputSubPathExpr(storage)
+	if hasSubPathExpr {
+		outputMount.SubPathExpr = subPathExpr
 	}
 
 	volumeMounts := []corev1.VolumeMount{
@@ -372,8 +377,10 @@ func getUploadContainer(
 		},
 	}
 
-	// Provide Pod identity env vars for subPathExpr expansion (used when PVC subPath is set).
-	container.Env = append(container.Env, podIdentityEnvVars()...)
+	// Provide pod name env var only when SubPathExpr is used (PVC subPath is set).
+	if hasSubPathExpr {
+		container.Env = append(container.Env, podNameEnvVars()...)
+	}
 
 	if httpProxy != "" {
 		container.Env = append(container.Env, corev1.EnvVar{Name: uploadEnvHttpProxy, Value: httpProxy})

--- a/controllers/mustgather/template.go
+++ b/controllers/mustgather/template.go
@@ -49,12 +49,6 @@ const (
 	// SSH directory and known hosts file
 	sshDir         = "/tmp/must-gather-operator/.ssh"
 	knownHostsFile = "/tmp/must-gather-operator/.ssh/known_hosts"
-
-	// Environment variable specifying the must-gather image
-	defaultMustGatherImageEnv = "DEFAULT_MUST_GATHER_IMAGE"
-
-	// Downward API environment variables used for subPathExpr expansion.
-	podNameEnvVar = "POD_NAME"
 )
 
 func outputSubPathExpr(storage *v1alpha1.Storage) (string, bool) {
@@ -64,12 +58,9 @@ func outputSubPathExpr(storage *v1alpha1.Storage) (string, bool) {
 
 	base := strings.TrimSpace(storage.PersistentVolume.SubPath)
 	base = strings.Trim(base, "/")
-	if base == "" {
-		return "", false
-	}
 
-	// Use user-provided base path, but isolate each run using the pod name
-	// to avoid overwriting prior collections on the PVC.
+	// Isolate each run using the pod name to avoid overwriting prior collections on the PVC.
+	// When base is empty, path.Join("", ...) yields just the pod name expr, giving per-run isolation at PVC root.
 	return path.Join(base, fmt.Sprintf("$(%s)", podNameEnvVar)), true
 }
 

--- a/controllers/mustgather/template_test.go
+++ b/controllers/mustgather/template_test.go
@@ -2,6 +2,7 @@ package mustgather
 
 import (
 	"fmt"
+	"path"
 	"reflect"
 	"strconv"
 	"strings"
@@ -139,7 +140,7 @@ func Test_getGatherContainer(t *testing.T) {
 			},
 		},
 		{
-			name:    "with PVC empty subPath does not set subPathExpr",
+			name:    "with PVC empty subPath sets subPathExpr to POD_NAME only",
 			timeout: 5 * time.Second,
 			storage: &mustgatherv1alpha1.Storage{
 				Type: mustgatherv1alpha1.StorageTypePersistentVolume,
@@ -150,7 +151,7 @@ func Test_getGatherContainer(t *testing.T) {
 			},
 		},
 		{
-			name:    "with PVC whitespace subPath does not set subPathExpr",
+			name:    "with PVC whitespace subPath sets subPathExpr to POD_NAME only",
 			timeout: 5 * time.Second,
 			storage: &mustgatherv1alpha1.Storage{
 				Type: mustgatherv1alpha1.StorageTypePersistentVolume,
@@ -161,7 +162,7 @@ func Test_getGatherContainer(t *testing.T) {
 			},
 		},
 		{
-			name:    "with PVC slash-only subPath does not set subPathExpr",
+			name:    "with PVC slash-only subPath sets subPathExpr to POD_NAME only",
 			timeout: 5 * time.Second,
 			storage: &mustgatherv1alpha1.Storage{
 				Type: mustgatherv1alpha1.StorageTypePersistentVolume,
@@ -222,15 +223,9 @@ func Test_getGatherContainer(t *testing.T) {
 					t.Fatalf("volume mount name was not correctly set. got %v, wanted %v", volumeMount.Name, outputVolumeName)
 				}
 				base := strings.Trim(strings.TrimSpace(tt.storage.PersistentVolume.SubPath), "/")
-				if base == "" {
-					if volumeMount.SubPathExpr != "" {
-						t.Fatalf("did not expect volume mount subPathExpr to be set when base subPath is empty, got %q", volumeMount.SubPathExpr)
-					}
-				} else {
-					wantExpr := fmt.Sprintf("%s/$(POD_NAME)", base)
-					if volumeMount.SubPathExpr != wantExpr {
-						t.Fatalf("volume mount subPathExpr was not correctly set. got %q, wanted %q", volumeMount.SubPathExpr, wantExpr)
-					}
+				wantExpr := path.Join(base, fmt.Sprintf("$(%s)", podNameEnvVar))
+				if volumeMount.SubPathExpr != wantExpr {
+					t.Fatalf("volume mount subPathExpr was not correctly set. got %q, wanted %q", volumeMount.SubPathExpr, wantExpr)
 				}
 				if volumeMount.SubPath != "" {
 					t.Fatalf("did not expect volume mount subPath to be set when using subPathExpr, got %q", volumeMount.SubPath)
@@ -247,18 +242,13 @@ func Test_getGatherContainer(t *testing.T) {
 					}
 				}
 			}
-			subPathBase := ""
-			if tt.storage != nil && tt.storage.Type == mustgatherv1alpha1.StorageTypePersistentVolume {
-				subPathBase = strings.Trim(strings.TrimSpace(tt.storage.PersistentVolume.SubPath), "/")
+			// SubPathExpr is always set for PVC storage (for per-pod isolation), so POD_NAME env is always present.
+			hasPVCStorage := tt.storage != nil && tt.storage.Type == mustgatherv1alpha1.StorageTypePersistentVolume
+			if hasPVCStorage && !hasPodNameEnv {
+				t.Fatalf("expected %s env var when PVC storage is used (SubPathExpr is set)", podNameEnvVar)
 			}
-			if subPathBase == "" {
-				if hasPodNameEnv {
-					t.Fatalf("did not expect %s env var when PVC subPath is empty", podNameEnvVar)
-				}
-			} else {
-				if !hasPodNameEnv {
-					t.Fatalf("expected %s env var when PVC subPath is set (base=%q)", podNameEnvVar, subPathBase)
-				}
+			if !hasPVCStorage && hasPodNameEnv {
+				t.Fatalf("did not expect %s env var when storage is not PVC", podNameEnvVar)
 			}
 		})
 	}
@@ -349,7 +339,7 @@ func Test_getUploadContainer(t *testing.T) {
 			},
 		},
 		{
-			name:          "With PVC empty subPath does not set subPathExpr",
+			name:          "With PVC empty subPath sets subPathExpr to POD_NAME only",
 			operatorImage: "testImage",
 			caseId:        "1234",
 			secretKeyRefName: v1.LocalObjectReference{
@@ -364,7 +354,7 @@ func Test_getUploadContainer(t *testing.T) {
 			},
 		},
 		{
-			name:          "With PVC whitespace subPath does not set subPathExpr",
+			name:          "With PVC whitespace subPath sets subPathExpr to POD_NAME only",
 			operatorImage: "testImage",
 			caseId:        "1234",
 			secretKeyRefName: v1.LocalObjectReference{
@@ -379,7 +369,7 @@ func Test_getUploadContainer(t *testing.T) {
 			},
 		},
 		{
-			name:          "With PVC slash-only subPath does not set subPathExpr",
+			name:          "With PVC slash-only subPath sets subPathExpr to POD_NAME only",
 			operatorImage: "testImage",
 			caseId:        "1234",
 			secretKeyRefName: v1.LocalObjectReference{
@@ -428,22 +418,16 @@ func Test_getUploadContainer(t *testing.T) {
 					t.Fatalf("expected output volume mount %q to be present", outputVolumeName)
 				}
 				base := strings.Trim(strings.TrimSpace(tt.storage.PersistentVolume.SubPath), "/")
-				if base == "" {
-					if outputMount.SubPathExpr != "" {
-						t.Fatalf("did not expect output volume mount subPathExpr to be set when base subPath is empty, got %q", outputMount.SubPathExpr)
-					}
-				} else {
-					wantExpr := fmt.Sprintf("%s/$(POD_NAME)", base)
-					if outputMount.SubPathExpr != wantExpr {
-						t.Fatalf("expected output volume mount subPathExpr %q but got %q", wantExpr, outputMount.SubPathExpr)
-					}
+				wantExpr := path.Join(base, fmt.Sprintf("$(%s)", podNameEnvVar))
+				if outputMount.SubPathExpr != wantExpr {
+					t.Fatalf("expected output volume mount subPathExpr %q but got %q", wantExpr, outputMount.SubPathExpr)
 				}
 				if outputMount.SubPath != "" {
 					t.Fatalf("did not expect output volume mount subPath to be set when using subPathExpr, got %q", outputMount.SubPath)
 				}
 			}
 
-			// POD_NAME env var should be present only when SubPathExpr is used.
+			// POD_NAME env var is present when SubPathExpr is used (always for PVC storage).
 			hasPodNameEnv := false
 			for _, env := range container.Env {
 				if env.Name == podNameEnvVar {
@@ -453,18 +437,12 @@ func Test_getUploadContainer(t *testing.T) {
 					}
 				}
 			}
-			subPathBase := ""
-			if tt.storage != nil && tt.storage.Type == mustgatherv1alpha1.StorageTypePersistentVolume {
-				subPathBase = strings.Trim(strings.TrimSpace(tt.storage.PersistentVolume.SubPath), "/")
+			hasPVCStorage := tt.storage != nil && tt.storage.Type == mustgatherv1alpha1.StorageTypePersistentVolume
+			if hasPVCStorage && !hasPodNameEnv {
+				t.Fatalf("expected %s env var when PVC storage is used (SubPathExpr is set)", podNameEnvVar)
 			}
-			if subPathBase == "" {
-				if hasPodNameEnv {
-					t.Fatalf("did not expect %s env var when PVC subPath is empty", podNameEnvVar)
-				}
-			} else {
-				if !hasPodNameEnv {
-					t.Fatalf("expected %s env var when PVC subPath is set (base=%q)", podNameEnvVar, subPathBase)
-				}
+			if !hasPVCStorage && hasPodNameEnv {
+				t.Fatalf("did not expect %s env var when storage is not PVC", podNameEnvVar)
 			}
 
 			for _, env := range container.Env {

--- a/controllers/mustgather/template_test.go
+++ b/controllers/mustgather/template_test.go
@@ -139,6 +139,39 @@ func Test_getGatherContainer(t *testing.T) {
 			},
 		},
 		{
+			name:    "with PVC empty subPath does not set subPathExpr",
+			timeout: 5 * time.Second,
+			storage: &mustgatherv1alpha1.Storage{
+				Type: mustgatherv1alpha1.StorageTypePersistentVolume,
+				PersistentVolume: mustgatherv1alpha1.PersistentVolumeConfig{
+					Claim:   mustgatherv1alpha1.PersistentVolumeClaimReference{Name: "test-pvc"},
+					SubPath: "",
+				},
+			},
+		},
+		{
+			name:    "with PVC whitespace subPath does not set subPathExpr",
+			timeout: 5 * time.Second,
+			storage: &mustgatherv1alpha1.Storage{
+				Type: mustgatherv1alpha1.StorageTypePersistentVolume,
+				PersistentVolume: mustgatherv1alpha1.PersistentVolumeConfig{
+					Claim:   mustgatherv1alpha1.PersistentVolumeClaimReference{Name: "test-pvc"},
+					SubPath: "   ",
+				},
+			},
+		},
+		{
+			name:    "with PVC slash-only subPath does not set subPathExpr",
+			timeout: 5 * time.Second,
+			storage: &mustgatherv1alpha1.Storage{
+				Type: mustgatherv1alpha1.StorageTypePersistentVolume,
+				PersistentVolume: mustgatherv1alpha1.PersistentVolumeConfig{
+					Claim:   mustgatherv1alpha1.PersistentVolumeClaimReference{Name: "test-pvc"},
+					SubPath: "/",
+				},
+			},
+		},
+		{
 			name:            "robust timeout",
 			timeout:         6*time.Hour + 5*time.Minute + 3*time.Second, // 6h5m3s
 			mustGatherImage: "quay.io/foo/bar/must-gather:latest",
@@ -188,8 +221,19 @@ func Test_getGatherContainer(t *testing.T) {
 				if volumeMount.Name != outputVolumeName {
 					t.Fatalf("volume mount name was not correctly set. got %v, wanted %v", volumeMount.Name, outputVolumeName)
 				}
-				if volumeMount.SubPath != tt.storage.PersistentVolume.SubPath {
-					t.Fatalf("volume mount subpath was not correctly set. got %v, wanted %v", volumeMount.SubPath, tt.storage.PersistentVolume.SubPath)
+				base := strings.Trim(strings.TrimSpace(tt.storage.PersistentVolume.SubPath), "/")
+				if base == "" {
+					if volumeMount.SubPathExpr != "" {
+						t.Fatalf("did not expect volume mount subPathExpr to be set when base subPath is empty, got %q", volumeMount.SubPathExpr)
+					}
+				} else {
+					wantExpr := fmt.Sprintf("%s/$(POD_NAME)", base)
+					if volumeMount.SubPathExpr != wantExpr {
+						t.Fatalf("volume mount subPathExpr was not correctly set. got %q, wanted %q", volumeMount.SubPathExpr, wantExpr)
+					}
+				}
+				if volumeMount.SubPath != "" {
+					t.Fatalf("did not expect volume mount subPath to be set when using subPathExpr, got %q", volumeMount.SubPath)
 				}
 			}
 		})
@@ -203,6 +247,7 @@ func Test_getUploadContainer(t *testing.T) {
 		caseId           string
 		host             string
 		internalUser     bool
+		storage          *mustgatherv1alpha1.Storage
 		httpProxy        string
 		httpsProxy       string
 		noProxy          string
@@ -262,11 +307,73 @@ func Test_getUploadContainer(t *testing.T) {
 			secretKeyRefName: v1.LocalObjectReference{Name: "testSecretKeyRefName"},
 			mountCAConfigMap: true,
 		},
+		{
+			name:          "With PVC subPath",
+			operatorImage: "testImage",
+			caseId:        "1234",
+			secretKeyRefName: v1.LocalObjectReference{
+				Name: "testSecretKeyRefName",
+			},
+			storage: &mustgatherv1alpha1.Storage{
+				Type: mustgatherv1alpha1.StorageTypePersistentVolume,
+				PersistentVolume: mustgatherv1alpha1.PersistentVolumeConfig{
+					Claim: mustgatherv1alpha1.PersistentVolumeClaimReference{
+						Name: "test-pvc",
+					},
+					SubPath: "test-path",
+				},
+			},
+		},
+		{
+			name:          "With PVC empty subPath does not set subPathExpr",
+			operatorImage: "testImage",
+			caseId:        "1234",
+			secretKeyRefName: v1.LocalObjectReference{
+				Name: "testSecretKeyRefName",
+			},
+			storage: &mustgatherv1alpha1.Storage{
+				Type: mustgatherv1alpha1.StorageTypePersistentVolume,
+				PersistentVolume: mustgatherv1alpha1.PersistentVolumeConfig{
+					Claim:   mustgatherv1alpha1.PersistentVolumeClaimReference{Name: "test-pvc"},
+					SubPath: "",
+				},
+			},
+		},
+		{
+			name:          "With PVC whitespace subPath does not set subPathExpr",
+			operatorImage: "testImage",
+			caseId:        "1234",
+			secretKeyRefName: v1.LocalObjectReference{
+				Name: "testSecretKeyRefName",
+			},
+			storage: &mustgatherv1alpha1.Storage{
+				Type: mustgatherv1alpha1.StorageTypePersistentVolume,
+				PersistentVolume: mustgatherv1alpha1.PersistentVolumeConfig{
+					Claim:   mustgatherv1alpha1.PersistentVolumeClaimReference{Name: "test-pvc"},
+					SubPath: "   ",
+				},
+			},
+		},
+		{
+			name:          "With PVC slash-only subPath does not set subPathExpr",
+			operatorImage: "testImage",
+			caseId:        "1234",
+			secretKeyRefName: v1.LocalObjectReference{
+				Name: "testSecretKeyRefName",
+			},
+			storage: &mustgatherv1alpha1.Storage{
+				Type: mustgatherv1alpha1.StorageTypePersistentVolume,
+				PersistentVolume: mustgatherv1alpha1.PersistentVolumeConfig{
+					Claim:   mustgatherv1alpha1.PersistentVolumeClaimReference{Name: "test-pvc"},
+					SubPath: "/",
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			testFailed := false
-			container := getUploadContainer(tt.operatorImage, tt.caseId, tt.host, tt.internalUser, tt.httpProxy, tt.httpsProxy, tt.noProxy, tt.secretKeyRefName, tt.mountCAConfigMap)
+			container := getUploadContainer(tt.operatorImage, tt.caseId, tt.host, tt.internalUser, tt.storage, tt.httpProxy, tt.httpsProxy, tt.noProxy, tt.secretKeyRefName, tt.mountCAConfigMap)
 
 			if container.Image != tt.operatorImage {
 				t.Fatalf("expected container image %v but got %v", tt.operatorImage, container.Image)
@@ -282,6 +389,33 @@ func Test_getUploadContainer(t *testing.T) {
 
 				if !mountedCAExists {
 					t.Fatalf("expected a CA cert volumeMount in upload container")
+				}
+			}
+
+			if tt.storage != nil && tt.storage.Type == mustgatherv1alpha1.StorageTypePersistentVolume {
+				var outputMount *v1.VolumeMount
+				for i := range container.VolumeMounts {
+					if container.VolumeMounts[i].Name == outputVolumeName {
+						outputMount = &container.VolumeMounts[i]
+						break
+					}
+				}
+				if outputMount == nil {
+					t.Fatalf("expected output volume mount %q to be present", outputVolumeName)
+				}
+				base := strings.Trim(strings.TrimSpace(tt.storage.PersistentVolume.SubPath), "/")
+				if base == "" {
+					if outputMount.SubPathExpr != "" {
+						t.Fatalf("did not expect output volume mount subPathExpr to be set when base subPath is empty, got %q", outputMount.SubPathExpr)
+					}
+				} else {
+					wantExpr := fmt.Sprintf("%s/$(POD_NAME)", base)
+					if outputMount.SubPathExpr != wantExpr {
+						t.Fatalf("expected output volume mount subPathExpr %q but got %q", wantExpr, outputMount.SubPathExpr)
+					}
+				}
+				if outputMount.SubPath != "" {
+					t.Fatalf("did not expect output volume mount subPath to be set when using subPathExpr, got %q", outputMount.SubPath)
 				}
 			}
 

--- a/controllers/mustgather/template_test.go
+++ b/controllers/mustgather/template_test.go
@@ -236,6 +236,30 @@ func Test_getGatherContainer(t *testing.T) {
 					t.Fatalf("did not expect volume mount subPath to be set when using subPathExpr, got %q", volumeMount.SubPath)
 				}
 			}
+
+			// POD_NAME env var should be present only when SubPathExpr is used.
+			hasPodNameEnv := false
+			for _, env := range container.Env {
+				if env.Name == podNameEnvVar {
+					hasPodNameEnv = true
+					if env.ValueFrom == nil || env.ValueFrom.FieldRef == nil || env.ValueFrom.FieldRef.FieldPath != "metadata.name" {
+						t.Fatalf("expected %s env var to be sourced from metadata.name via fieldRef, got %#v", podNameEnvVar, env)
+					}
+				}
+			}
+			subPathBase := ""
+			if tt.storage != nil && tt.storage.Type == mustgatherv1alpha1.StorageTypePersistentVolume {
+				subPathBase = strings.Trim(strings.TrimSpace(tt.storage.PersistentVolume.SubPath), "/")
+			}
+			if subPathBase == "" {
+				if hasPodNameEnv {
+					t.Fatalf("did not expect %s env var when PVC subPath is empty", podNameEnvVar)
+				}
+			} else {
+				if !hasPodNameEnv {
+					t.Fatalf("expected %s env var when PVC subPath is set (base=%q)", podNameEnvVar, subPathBase)
+				}
+			}
 		})
 	}
 }
@@ -416,6 +440,30 @@ func Test_getUploadContainer(t *testing.T) {
 				}
 				if outputMount.SubPath != "" {
 					t.Fatalf("did not expect output volume mount subPath to be set when using subPathExpr, got %q", outputMount.SubPath)
+				}
+			}
+
+			// POD_NAME env var should be present only when SubPathExpr is used.
+			hasPodNameEnv := false
+			for _, env := range container.Env {
+				if env.Name == podNameEnvVar {
+					hasPodNameEnv = true
+					if env.ValueFrom == nil || env.ValueFrom.FieldRef == nil || env.ValueFrom.FieldRef.FieldPath != "metadata.name" {
+						t.Fatalf("expected %s env var to be sourced from metadata.name via fieldRef, got %#v", podNameEnvVar, env)
+					}
+				}
+			}
+			subPathBase := ""
+			if tt.storage != nil && tt.storage.Type == mustgatherv1alpha1.StorageTypePersistentVolume {
+				subPathBase = strings.Trim(strings.TrimSpace(tt.storage.PersistentVolume.SubPath), "/")
+			}
+			if subPathBase == "" {
+				if hasPodNameEnv {
+					t.Fatalf("did not expect %s env var when PVC subPath is empty", podNameEnvVar)
+				}
+			} else {
+				if !hasPodNameEnv {
+					t.Fatalf("expected %s env var when PVC subPath is set (base=%q)", podNameEnvVar, subPathBase)
 				}
 			}
 

--- a/deploy/must-gather-pvc.yaml
+++ b/deploy/must-gather-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: must-gather-pvc
+  namespace: must-gather-operator
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/examples/mustgather_with_pvc_subpath.yaml
+++ b/examples/mustgather_with_pvc_subpath.yaml
@@ -1,0 +1,19 @@
+apiVersion: operator.openshift.io/v1alpha1
+kind: MustGather
+metadata:
+  name: example-mustgather-pvc-subpath
+spec:
+  serviceAccountName: must-gather-admin
+  storage:
+    type: PersistentVolume
+    persistentVolume:
+      claim:
+        name: must-gather-pvc
+      subPath: must-gather-data
+  uploadTarget:
+    type: SFTP
+    sftp:
+      caseID: '04230315'
+      caseManagementAccountSecretRef:
+        name: case-management-creds
+      internalUser: true

--- a/examples/other_resources/07_must-gather-pvc-test.yaml
+++ b/examples/other_resources/07_must-gather-pvc-test.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: must-gather-pvc-test
+spec:
+  containers:
+  - name: test-container
+    image: busybox:1.36
+    command: ["/bin/sh"]
+    args: ["-c", "while true; do echo \"Test write to must-gather-pvc at $(date)\" >> /data/must-gather-test.txt; sleep 30; done"]
+    volumeMounts:
+    - mountPath: /data
+      name: must-gather-storage
+  volumes:
+  - name: must-gather-storage
+    persistentVolumeClaim:
+      claimName: must-gather-pvc

--- a/test/e2e/must_gather_operator_test.go
+++ b/test/e2e/must_gather_operator_test.go
@@ -1473,7 +1473,8 @@ var _ = ginkgo.Describe("MustGather resource", ginkgo.Ordered, func() {
 				}
 			}
 			Expect(outputMount).NotTo(BeNil(), "Gather container should have output volume mount")
-			Expect(outputMount.SubPath).To(Equal(subPath), "Volume mount should have subPath configured")
+			Expect(outputMount.SubPathExpr).To(Equal(subPath+"/$(POD_NAME)"), "Volume mount should have subPathExpr configured")
+			Expect(outputMount.SubPath).To(BeEmpty(), "Volume mount subPath should be empty when using subPathExpr")
 		})
 
 		ginkgo.It("should create MustGather with PVC storage, configure Job correctly, and persist data", func() {


### PR DESCRIPTION
[OCPBUGS-64626](https://issues.redhat.com/browse/OCPBUGS-64626):

- Updated subPath with subPathExpr to use $(POD_NAME)

- Added the conditional env variable POD_NAME to both gather and upload containers mount the same PVC-backed output volume using volumeMount.subPathExpr. 

- Added a new example CR examples/mustgather_with_pvc_subpath.yaml showing how to configure PVC storage with subPath.

- Updated unit + e2e tests and refreshed related comments to match the new behavior.