### PR TITLE
[release-4.21] MG-198: Add update-metadata.sh for Support Log Gather

### DIFF
--- a/bundle/manifests/support-log-gather-operator.package.yaml
+++ b/bundle/manifests/support-log-gather-operator.package.yaml
@@ -1,4 +1,4 @@
 packageName: support-log-gather-operator
 channels:
-- name: tech-preview
-  currentCSV: support-log-gather-operator.v4.20.0
+  - name: tech-preview
+    currentCSV: support-log-gather-operator.v4.21.0

--- a/bundle/manifests/tech-preview/support-log-gather-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/tech-preview/support-log-gather-operator.clusterserviceversion.yaml
@@ -1,7 +1,7 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
-  name: support-log-gather-operator.v4.20.0
+  name: support-log-gather-operator.v4.21.0
   namespace: must-gather-operator
   annotations:
     categories: Monitoring, Application Runtime
@@ -12,7 +12,7 @@ metadata:
     createdAt: "2020-07-31T16:12:36Z"
     support: Red Hat
     repository: https://github.com/openshift/must-gather-operator
-    olm.skipRange: ">=4.20.0-0 <4.20.0"
+    olm.skipRange: ">=4.20.0-0 <4.21.0"
     features.operators.openshift.io/disconnected: "false"
     features.operators.openshift.io/fips-compliant: "true"
     features.operators.openshift.io/proxy-aware: "true"
@@ -23,6 +23,7 @@ metadata:
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "true"
+    olm.properties: '[{"type":"olm.maxOpenShiftVersion","value":"4.22"}]'
   labels:
     operator-metering: "true"
     operatorframework.io/arch.amd64: supported
@@ -34,28 +35,27 @@ spec:
   displayName: support log gather
   description: |
     An operator that collects logs in Red Hat OpenShift and sends them to Red Hat Support for troubleshooting.
-    
+
     ## Features
-    
+
     * Automated must-gather collection
     * Secure collection and storage
-
   icon:
     - base64data: PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxOTIgMTQ1Ij48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UwMDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlJlZEhhdC1Mb2dvLUhhdC1Db2xvcjwvdGl0bGU+PHBhdGggZD0iTTE1Ny43Nyw2Mi42MWExNCwxNCwwLDAsMSwuMzEsMy40MmMwLDE0Ljg4LTE4LjEsMTcuNDYtMzAuNjEsMTcuNDZDNzguODMsODMuNDksNDIuNTMsNTMuMjYsNDIuNTMsNDRhNi40Myw2LjQzLDAsMCwxLC4yMi0xLjk0bC0zLjY2LDkuMDZhMTguNDUsMTguNDUsMCwwLDAtMS41MSw3LjMzYzAsMTguMTEsNDEsNDUuNDgsODcuNzQsNDUuNDgsMjAuNjksMCwzNi40My03Ljc2LDM2LjQzLTIxLjc3LDAtMS4wOCwwLTEuOTQtMS43My0xMC4xM1oiLz48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik0xMjcuNDcsODMuNDljMTIuNTEsMCwzMC42MS0yLjU4LDMwLjYxLTE3LjQ2YTE0LDE0LDAsMCwwLS4zMS0zLjQybC03LjQ1LTMyLjM2Yy0xLjcyLTcuMTItMy4yMy0xMC4zNS0xNS43My0xNi42QzEyNC44OSw4LjY5LDEwMy43Ni41LDk3LjUxLjUsOTEuNjkuNSw5MCw4LDgzLjA2LDhjLTYuNjgsMC0xMS42NC01LjYtMTcuODktNS42LTYsMC05LjkxLDQuMDktMTIuOTMsMTIuNSwwLDAtOC40MSwyMy43Mi05LjQ5LDI3LjE2QTYuNDMsNi40MywwLDAsMCw0Mi41Myw0NGMwLDkuMjIsMzYuMywzOS40NSw4NC45NCwzOS40NU0xNjAsNzIuMDdjMS43Myw4LjE5LDEuNzMsOS4wNSwxLjczLDEwLjEzLDAsMTQtMTUuNzQsMjEuNzctMzYuNDMsMjEuNzdDNzguNTQsMTA0LDM3LjU4LDc2LjYsMzcuNTgsNTguNDlhMTguNDUsMTguNDUsMCwwLDEsMS41MS03LjMzQzIyLjI3LDUyLC41LDU1LC41LDc0LjIyYzAsMzEuNDgsNzQuNTksNzAuMjgsMTMzLjY1LDcwLjI4LDQ1LjI4LDAsNTYuNy0yMC40OCw1Ni43LTM2LjY1LDAtMTIuNzItMTEtMjcuMTYtMzAuODMtMzUuNzgiLz48L3N2Zz4=
       mediatype: image/svg+xml
   keywords:
-  - kubernetes
-  - openshift
-  - monitoring
-  - diagnostics
-  - must-gather
-  - support
+    - kubernetes
+    - openshift
+    - monitoring
+    - diagnostics
+    - must-gather
+    - support
   links:
     - name: Documentation
       url: https://github.com/openshift/must-gather-operator
     - name: Source Repository
       url: https://github.com/openshift/must-gather-operator
-  version: 4.20.0
+  version: 4.21.0
   maturity: tech-preview
   maintainers:
     - email: aos-staff@redhat.com
@@ -64,180 +64,180 @@ spec:
   provider:
     name: Red Hat, Inc
   installModes:
-  - type: OwnNamespace
-    supported: false
-  - type: SingleNamespace
-    supported: false
-  - type: MultiNamespace
-    supported: false
-  - type: AllNamespaces
-    supported: true
+    - type: OwnNamespace
+      supported: false
+    - type: SingleNamespace
+      supported: false
+    - type: MultiNamespace
+      supported: false
+    - type: AllNamespaces
+      supported: true
   install:
     strategy: deployment
     spec:
       clusterPermissions:
-      - serviceAccountName: must-gather-operator
-        rules:
-        - apiGroups:
-          - ""
-          resources:
-          - pods
-          - services
-          - services/finalizers
-          - endpoints
-          - persistentvolumeclaims
-          - events
-          - configmaps
-          - secrets
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - apps
-          resources:
-          - deployments
-          - daemonsets
-          - replicasets
-          - statefulsets
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - monitoring.coreos.com
-          resources:
-          - servicemonitors
-          verbs:
-          - get
-          - create
-        - apiGroups:
-          - apps
-          resourceNames:
-          - must-gather-operator
-          resources:
-          - deployments/finalizers
-          verbs:
-          - update
-        - apiGroups:
-          - ""
-          resources:
-          - pods
-          verbs:
-          - get
-        - apiGroups:
-          - apps
-          resources:
-          - replicasets
-          - deployments
-          verbs:
-          - get
-        - apiGroups:
-          - operator.openshift.io
-          resources:
-          - mustgathers
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - operator.openshift.io
-          resources:
-          - mustgathers/status
-          verbs:
-          - get
-          - patch
-          - update
-        - apiGroups:
-          - operator.openshift.io
-          resources:
-          - mustgathers/finalizers
-          verbs:
-          - update
-        - apiGroups:
-          - config.openshift.io
-          resources:
-          - clusterversions
-          verbs:
-          - get
-          - list
-          - watch
-        - apiGroups:
-          - batch
-          resources:
-          - jobs
-          - jobs/finalizers
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-      deployments:
-      - name: must-gather-operator
-        spec:
-          replicas: 1
-          selector:
-            matchLabels:
-              name: must-gather-operator
-          strategy: {}
-          template:
-            metadata:
-              labels:
-                name: must-gather-operator
-            spec:
-              containers:
-              - command:
+        - serviceAccountName: must-gather-operator
+          rules:
+            - apiGroups:
+                - ""
+              resources:
+                - pods
+                - services
+                - services/finalizers
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                - configmaps
+                - secrets
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - apps
+              resources:
+                - deployments
+                - daemonsets
+                - replicasets
+                - statefulsets
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - monitoring.coreos.com
+              resources:
+                - servicemonitors
+              verbs:
+                - get
+                - create
+            - apiGroups:
+                - apps
+              resourceNames:
                 - must-gather-operator
-                env:
-                - name: OPERATOR_NAME
-                  value: must-gather-operator
-                - name: DEFAULT_MUST_GATHER_IMAGE
-                  value: quay.io/openshift/origin-must-gather:latest
-                - name: OPERATOR_IMAGE
-                  value: quay.io/openshift/origin-support-log-gather-operator:latest
-                - name: OPERATOR_NAMESPACE
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.namespace
-                - name: POD_NAME
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.name
-                - name: WATCH_NAMESPACE
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/openshift/origin-support-log-gather-operator:latest
-                imagePullPolicy: Always
+              resources:
+                - deployments/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - ""
+              resources:
+                - pods
+              verbs:
+                - get
+            - apiGroups:
+                - apps
+              resources:
+                - replicasets
+                - deployments
+              verbs:
+                - get
+            - apiGroups:
+                - operator.openshift.io
+              resources:
+                - mustgathers
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - operator.openshift.io
+              resources:
+                - mustgathers/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - operator.openshift.io
+              resources:
+                - mustgathers/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - config.openshift.io
+              resources:
+                - clusterversions
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - batch
+              resources:
+                - jobs
+                - jobs/finalizers
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+      deployments:
+        - name: must-gather-operator
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
                 name: must-gather-operator
-                resources:
-                  limits:
-                    cpu: 200m
-                    memory: 512Mi
-                  requests:
-                    cpu: 100m
-                    memory: 256Mi
-              serviceAccountName: must-gather-operator
+            strategy: {}
+            template:
+              metadata:
+                labels:
+                  name: must-gather-operator
+              spec:
+                containers:
+                  - command:
+                      - must-gather-operator
+                    env:
+                      - name: OPERATOR_NAME
+                        value: must-gather-operator
+                      - name: DEFAULT_MUST_GATHER_IMAGE
+                        value: quay.io/openshift/origin-must-gather:latest
+                      - name: OPERATOR_IMAGE
+                        value: quay.io/openshift/origin-support-log-gather-operator:latest
+                      - name: OPERATOR_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.annotations['olm.targetNamespaces']
+                    image: quay.io/openshift/origin-support-log-gather-operator:latest
+                    imagePullPolicy: Always
+                    name: must-gather-operator
+                    resources:
+                      limits:
+                        cpu: 200m
+                        memory: 512Mi
+                      requests:
+                        cpu: 100m
+                        memory: 256Mi
+                serviceAccountName: must-gather-operator
   customresourcedefinitions:
     owned:
-    - displayName: Must Gather
-      group: operator.openshift.io
-      kind: MustGather
-      name: mustgathers.operator.openshift.io
-      description: Represents a must-gather diagnostic collection job
-      version: v1alpha1
+      - displayName: Must Gather
+        group: operator.openshift.io
+        kind: MustGather
+        name: mustgathers.operator.openshift.io
+        description: Represents a must-gather diagnostic collection job
+        version: v1alpha1

--- a/hack/update-metadata.sh
+++ b/hack/update-metadata.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Usage:
+#   ./hack/update-metadata.sh [OCP_VERSION]
+#
+#   OCP_VERSION is an optional argument. If no argument is provided, it defaults
+#   to the version found in .channels[0].currentCSV in PACKAGE_MANIFEST.
+#   This means you can run `./hack/update-metadata.sh` to update the manifests
+#   using the current package version, or you can for example run
+#   `./hack/update-metadata.sh 4.21` to set the package version to 4.21.
+#   Both PACKAGE_MANIFEST and CSV_MANIFEST will be updated by this script.
+
+PACKAGE_MANIFEST=bundle/manifests/support-log-gather-operator.package.yaml
+CHANNEL=$(yq '.channels[0].name' ${PACKAGE_MANIFEST})
+CURRENT_CSV=$(yq '.channels[0].currentCSV' ${PACKAGE_MANIFEST})
+PACKAGE_NAME=$(echo ${CURRENT_CSV} | sed 's/\.v.*$//')
+PACKAGE_VERSION=$(echo ${CURRENT_CSV} | sed 's/^.*\.v//')
+
+if [ -z "${CHANNEL}" ] ||
+   [ -z "${PACKAGE_NAME}" ] ||
+   [ -z "${PACKAGE_VERSION}" ]; then
+    echo "Failed to parse ${PACKAGE_MANIFEST}"
+    exit 1
+fi
+
+CSV_MANIFEST=bundle/manifests/${CHANNEL}/${PACKAGE_NAME}.clusterserviceversion.yaml
+METADATA_NAME=$(yq ' "" + .metadata.name' ${CSV_MANIFEST})
+SKIP_RANGE=$(yq ' "" + .metadata.annotations["olm.skipRange"]' ${CSV_MANIFEST})
+SPEC_VERSION=$(yq ' "" + .spec.version' ${CSV_MANIFEST})
+
+# olm.properties may not exist yet, so use default if missing
+OLM_PROPERTIES=$(yq ' "" + .metadata.annotations["olm.properties"]' ${CSV_MANIFEST})
+if [ "${OLM_PROPERTIES}" == "null" ] || [ -z "${OLM_PROPERTIES}" ]; then
+    echo "Warning: olm.properties not found in CSV, will be created with default value"
+    OLM_PROPERTIES='[{"type":"olm.maxOpenShiftVersion","value":"4.21"}]'
+fi
+
+if [ -z "${METADATA_NAME}" ] ||
+   [ -z "${SKIP_RANGE}" ] ||
+   [ -z "${SPEC_VERSION}" ]; then
+    echo "Failed to parse ${CSV_MANIFEST}"
+    exit 1
+fi
+
+OCP_VERSION=${1:-${PACKAGE_VERSION}}
+IFS='.' read -r MAJOR_VERSION MINOR_VERSION PATCH_VERSION <<< "${OCP_VERSION}"
+PATCH_VERSION=${PATCH_VERSION:-0}
+if [ "${OCP_VERSION}" != "${PACKAGE_VERSION}" ]; then
+    PACKAGE_VERSION="${MAJOR_VERSION}.${MINOR_VERSION}.${PATCH_VERSION}"
+fi
+
+export NEW_CURRENT_CSV="${PACKAGE_NAME}.v${PACKAGE_VERSION}"
+export NEW_METADATA_NAME="${PACKAGE_NAME}.v${PACKAGE_VERSION}"
+export NEW_SKIP_RANGE=$(echo ${SKIP_RANGE} | sed "s/ <.*$/ <${PACKAGE_VERSION}/")
+export NEW_OLM_PROPERTIES=$(echo "${OLM_PROPERTIES}" | jq -c 'map(if .type=="olm.maxOpenShiftVersion" then .value="'${MAJOR_VERSION}.$((MINOR_VERSION + 1))'" else . end)')
+export NEW_SPEC_VERSION="${PACKAGE_VERSION}"
+
+if [ -z "${NEW_METADATA_NAME}" ] ||
+   [ -z "${NEW_SKIP_RANGE}" ] ||
+   [ -z "${NEW_OLM_PROPERTIES}" ] ||
+   [ -z "${NEW_SPEC_VERSION}" ]; then
+    echo "Failed to generate new values for ${CSV_MANIFEST}"
+    exit 1
+fi
+
+echo "Updating package manifest to ${PACKAGE_VERSION}"
+yq -i '.channels[0].currentCSV = strenv(NEW_CURRENT_CSV)' ${PACKAGE_MANIFEST}
+
+echo "Updating OLM metadata to ${PACKAGE_VERSION}"
+yq -i '
+  .metadata.name = strenv(NEW_METADATA_NAME) |
+  .metadata.annotations["olm.skipRange"] = strenv(NEW_SKIP_RANGE) |
+  .metadata.annotations["olm.properties"] = strenv(NEW_OLM_PROPERTIES) |
+  .spec.version = strenv(NEW_SPEC_VERSION)
+' ${CSV_MANIFEST}
+
+echo ""
+echo "Successfully updated OLM metadata to version ${PACKAGE_VERSION}"
+echo "  - Package CSV: ${NEW_CURRENT_CSV}"
+echo "  - Skip Range: ${NEW_SKIP_RANGE}"
+echo "  - Max OpenShift Version: ${MAJOR_VERSION}.$((MINOR_VERSION + 1))"
+echo ""
+echo "Updated files:"
+echo "  - ${PACKAGE_MANIFEST}"
+echo "  - ${CSV_MANIFEST}"


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                 
                                                                                                                                                                                             
  Add automated script for updating OLM metadata versions, aligning with similar operators in the OpenShift ecosystem.                                                                       
                                                                                                                                                                                             
  ## Motivation                                                                                                                                                                              
                                                                                                                                                                                             
  As requested in the conversation with @mytreya-rh, @shivprakashmuley, @swghosh  , we need to maintain OLM version metadata similar to other OpenShift operators like:                                                        
  - `local-storage-operator`                                                                                                                                                                 
  - `aws-efs-csi-driver-operator`                                                                                                                                                            
  - `gcp-filestore-csi-driver-operator`                                                                                                                                                      
  - `secrets-store-csi-driver-operator`                                                                                                                                                      
  - `smb-csi-driver-operator`                                                                                                                                                                
                                                                                                                                                                                             
  This script provides a consistent, automated way to update version information across OLM manifests.                                                                                       
                                                                                                                                                                                             
  ## Changes                                                                                                                                                                                 
                                                                                                                                                                                             
  - Added `hack/update-metadata.sh` script that automatically updates:                                                                                                                       
    - Package manifest (`bundle/manifests/support-log-gather-operator.package.yaml`)                                                                                                         
      - `channels[0].currentCSV`                                                                                                                                                             
    - ClusterServiceVersion (`bundle/manifests/tech-preview/support-log-gather-operator.clusterserviceversion.yaml`)                                                                         
      - `metadata.name`                                                                                                                                                                      
      - `metadata.annotations["olm.skipRange"]`                                                                                                                                              
      - `metadata.annotations["olm.properties"]` (creates if missing)                                                                                                                        
      - `spec.version`                                                                                                                                                                       
    - Automatically calculates `olm.maxOpenShiftVersion` as target version + 1                                                                                                               
                                                                                                                                                                                             
  ## Usage                                                                                                                                                                                   
                                                                                                                                                                                             
  ```bash                                                                                                                                                                                    
  # Update using current package version                                                                                                                                                     
  ./hack/update-metadata.sh                                                                                                                                                                  
                                                                                                                                                                                             
  # Update to specific OCP version (e.g., 4.21)                                                                                                                                              
  ./hack/update-metadata.sh 4.21                                                                                                                                                             
                                                                                                                                                                                             
  Example Output                                                                                                                                                                             
                                                                                                                                                                                             
  Successfully updated OLM metadata to version 4.21.0                                                                                                                                        
    - Package CSV: support-log-gather-operator.v4.21.0                                                                                                                                       
    - Skip Range: >=4.20.0-0 <4.21.0                                                                                                                                                         
    - Max OpenShift Version: 4.22                                                                                                                                                            
                                                                                                                                                                                             
  Testing                                                                                                                                                                                    
                                                                                                                                                                                             
  - ✅ Tested updating to current version (4.20.0)                                                                                                                                           
  - ✅ Tested updating to new version (4.21.0)                                                                                                                                               
  - ✅ Verified all fields are correctly updated                                                                                                                                             
  - ✅ Confirmed olm.properties is created when missing                                                                                                                                      
                                                                                                                                                                                             
  References                                                                                                                                                                                 
                                                                                                                                                                                             
  - Based on similar scripts from:                                                                                                                                                           
    - https://github.com/openshift/local-storage-operator/blob/main/hack/update-metadata.sh                                                                                                  
    - https://github.com/openshift/secrets-store-csi-driver-operator/blob/main/hack/update-metadata.sh    