### PR TITLE
MG-236: Supporting command and args with default must-gather image

### DIFF
--- a/api/v1alpha1/mustgather_types.go
+++ b/api/v1alpha1/mustgather_types.go
@@ -25,6 +25,8 @@ import (
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
 // MustGatherSpec defines the desired state of MustGather
+// +kubebuilder:validation:XValidation:rule="!(has(self.imageStreamRef) && has(self.gatherSpec) && self.gatherSpec.audit)",message="audit cannot be enabled when using a custom image (imageStreamRef)"
+// +kubebuilder:validation:XValidation:rule="!(!has(self.imageStreamRef) && has(self.gatherSpec) && has(self.gatherSpec.command) && size(self.gatherSpec.command) > 0 && self.gatherSpec.audit)",message="audit cannot be enabled when gatherSpec.command is set with the default must-gather image"
 type MustGatherSpec struct {
 	// the service account to use to run the must gather job pod, defaults to default
 	// +kubebuilder:validation:Optional
@@ -38,7 +40,8 @@ type MustGatherSpec struct {
 
 	// GatherSpec allows overriding the command and/or arguments for the must-gather container
 	// (default or custom image from imageStreamRef) and configures time-based collection filters.
-	// Time-based filters (since, sinceTime) and audit apply regardless of ImageStreamRef.
+	// Time-based filters (since, sinceTime) apply regardless of imageStreamRef.
+	// Audit is only allowed with the default image and default gather command (see CRD validation rules).
 	// +kubebuilder:validation:Optional
 	GatherSpec *GatherSpec `json:"gatherSpec,omitempty"`
 
@@ -70,9 +73,8 @@ type MustGatherSpec struct {
 // +kubebuilder:validation:XValidation:rule="!(has(self.since) && has(self.sinceTime))",message="only one of since or sinceTime may be specified"
 type GatherSpec struct {
 	// +kubebuilder:validation:Optional
-	// Audit specifies whether to collect audit logs. This is translated to a signal
-	// or command that can be respected by the default image
-	// or any custom image designed to do so.
+	// Audit requests audit log collection via the default gather entrypoint.
+	// It must be false when imageStreamRef is set or when gatherSpec.command is set without imageStreamRef.
 	Audit bool `json:"audit,omitempty"`
 
 	// +kubebuilder:validation:Optional

--- a/api/v1alpha1/mustgather_types.go
+++ b/api/v1alpha1/mustgather_types.go
@@ -25,8 +25,8 @@ import (
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
 // MustGatherSpec defines the desired state of MustGather
-// +kubebuilder:validation:XValidation:rule="!(has(self.imageStreamRef) && has(self.gatherSpec) && self.gatherSpec.audit)",message="audit cannot be enabled when using a custom image (imageStreamRef)"
-// +kubebuilder:validation:XValidation:rule="!(!has(self.imageStreamRef) && has(self.gatherSpec) && has(self.gatherSpec.command) && size(self.gatherSpec.command) > 0 && self.gatherSpec.audit)",message="audit cannot be enabled when gatherSpec.command is set with the default must-gather image"
+// +kubebuilder:validation:XValidation:rule="!(has(self.imageStreamRef) && has(self.gatherSpec) && has(self.gatherSpec.audit) && self.gatherSpec.audit)",message="audit cannot be enabled when using a custom image (imageStreamRef)"
+// +kubebuilder:validation:XValidation:rule="!(!has(self.imageStreamRef) && has(self.gatherSpec) && has(self.gatherSpec.command) && size(self.gatherSpec.command) > 0 && has(self.gatherSpec.audit) && self.gatherSpec.audit)",message="audit cannot be enabled when gatherSpec.command is set with the default must-gather image"
 type MustGatherSpec struct {
 	// the service account to use to run the must gather job pod, defaults to default
 	// +kubebuilder:validation:Optional

--- a/api/v1alpha1/mustgather_types.go
+++ b/api/v1alpha1/mustgather_types.go
@@ -25,7 +25,6 @@ import (
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
 // MustGatherSpec defines the desired state of MustGather
-// +kubebuilder:validation:XValidation:rule="!(has(self.gatherSpec) && ((has(self.gatherSpec.command) && size(self.gatherSpec.command) > 0) || (has(self.gatherSpec.args) && size(self.gatherSpec.args) > 0))) || has(self.imageStreamRef)",message="command and args in gatherSpec can only be set when imageStreamRef is specified"
 type MustGatherSpec struct {
 	// the service account to use to run the must gather job pod, defaults to default
 	// +kubebuilder:validation:Optional
@@ -37,9 +36,8 @@ type MustGatherSpec struct {
 	// +kubebuilder:validation:Optional
 	ImageStreamRef *ImageStreamTagRef `json:"imageStreamRef,omitempty"`
 
-	// GatherSpec allows overriding the command and/or arguments for the custom must-gather image
-	// and configures time-based collection filters.
-	// The command and args fields are only honored when ImageStreamRef is specified.
+	// GatherSpec allows overriding the command and/or arguments for the must-gather container
+	// (default or custom image from imageStreamRef) and configures time-based collection filters.
 	// Time-based filters (since, sinceTime) and audit apply regardless of ImageStreamRef.
 	// +kubebuilder:validation:Optional
 	GatherSpec *GatherSpec `json:"gatherSpec,omitempty"`
@@ -78,15 +76,14 @@ type GatherSpec struct {
 	Audit bool `json:"audit,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// Command is a string array representing the entrypoint for the custom image.
-	// This field is only honored when a custom image IS specified via imageStreamRef.
+	// Command is a string array representing the container entrypoint.
+	// When set, it replaces the default gather wrapper for both the default must-gather image and custom images.
 	// +kubebuilder:validation:MaxItems=256
 	// +kubebuilder:validation:Items:MaxLength=256
 	Command []string `json:"command,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// Args is a string array of arguments passed to the custom image's command.
-	// This field is only honored when a custom image IS specified via imageStreamRef.
+	// Args is a string array of arguments passed to the container command.
 	// +kubebuilder:validation:MaxItems=256
 	// +kubebuilder:validation:Items:MaxLength=256
 	Args []string `json:"args,omitempty"`

--- a/bundle/manifests/tech-preview/operator.openshift.io_mustgathers.yaml
+++ b/bundle/manifests/tech-preview/operator.openshift.io_mustgathers.yaml
@@ -43,7 +43,8 @@ spec:
                 description: |-
                   GatherSpec allows overriding the command and/or arguments for the must-gather container
                   (default or custom image from imageStreamRef) and configures time-based collection filters.
-                  Time-based filters (since, sinceTime) and audit apply regardless of ImageStreamRef.
+                  Time-based filters (since, sinceTime) apply regardless of imageStreamRef.
+                  Audit is only allowed with the default image and default gather command (see CRD validation rules).
                 properties:
                   args:
                     description: Args is a string array of arguments passed to the
@@ -54,9 +55,8 @@ spec:
                     type: array
                   audit:
                     description: |-
-                      Audit specifies whether to collect audit logs. This is translated to a signal
-                      or command that can be respected by the default image
-                      or any custom image designed to do so.
+                      Audit requests audit log collection via the default gather entrypoint.
+                      It must be false when imageStreamRef is set or when gatherSpec.command is set without imageStreamRef.
                     type: boolean
                   command:
                     description: |-
@@ -227,6 +227,13 @@ spec:
                   rule: 'has(self.type) && self.type == ''SFTP'' ? has(self.sftp)
                     : !has(self.sftp)'
             type: object
+            x-kubernetes-validations:
+            - message: audit cannot be enabled when using a custom image (imageStreamRef)
+              rule: '!(has(self.imageStreamRef) && has(self.gatherSpec) && self.gatherSpec.audit)'
+            - message: audit cannot be enabled when gatherSpec.command is set with
+                the default must-gather image
+              rule: '!(!has(self.imageStreamRef) && has(self.gatherSpec) && has(self.gatherSpec.command)
+                && size(self.gatherSpec.command) > 0 && self.gatherSpec.audit)'
           status:
             description: MustGatherStatus defines the observed state of MustGather
             properties:

--- a/bundle/manifests/tech-preview/operator.openshift.io_mustgathers.yaml
+++ b/bundle/manifests/tech-preview/operator.openshift.io_mustgathers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.16.4
   name: mustgathers.operator.openshift.io
 spec:
   group: operator.openshift.io
@@ -41,15 +41,13 @@ spec:
             properties:
               gatherSpec:
                 description: |-
-                  GatherSpec allows overriding the command and/or arguments for the custom must-gather image
-                  and configures time-based collection filters.
-                  The command and args fields are only honored when ImageStreamRef is specified.
+                  GatherSpec allows overriding the command and/or arguments for the must-gather container
+                  (default or custom image from imageStreamRef) and configures time-based collection filters.
                   Time-based filters (since, sinceTime) and audit apply regardless of ImageStreamRef.
                 properties:
                   args:
-                    description: |-
-                      Args is a string array of arguments passed to the custom image's command.
-                      This field is only honored when a custom image IS specified via imageStreamRef.
+                    description: Args is a string array of arguments passed to the
+                      container command.
                     items:
                       type: string
                     maxItems: 256
@@ -62,8 +60,8 @@ spec:
                     type: boolean
                   command:
                     description: |-
-                      Command is a string array representing the entrypoint for the custom image.
-                      This field is only honored when a custom image IS specified via imageStreamRef.
+                      Command is a string array representing the container entrypoint.
+                      When set, it replaces the default gather wrapper for both the default must-gather image and custom images.
                     items:
                       type: string
                     maxItems: 256
@@ -229,12 +227,6 @@ spec:
                   rule: 'has(self.type) && self.type == ''SFTP'' ? has(self.sftp)
                     : !has(self.sftp)'
             type: object
-            x-kubernetes-validations:
-            - message: command and args in gatherSpec can only be set when imageStreamRef
-                is specified
-              rule: '!(has(self.gatherSpec) && ((has(self.gatherSpec.command) && size(self.gatherSpec.command)
-                > 0) || (has(self.gatherSpec.args) && size(self.gatherSpec.args) >
-                0))) || has(self.imageStreamRef)'
           status:
             description: MustGatherStatus defines the observed state of MustGather
             properties:

--- a/bundle/manifests/tech-preview/operator.openshift.io_mustgathers.yaml
+++ b/bundle/manifests/tech-preview/operator.openshift.io_mustgathers.yaml
@@ -229,11 +229,13 @@ spec:
             type: object
             x-kubernetes-validations:
             - message: audit cannot be enabled when using a custom image (imageStreamRef)
-              rule: '!(has(self.imageStreamRef) && has(self.gatherSpec) && self.gatherSpec.audit)'
+              rule: '!(has(self.imageStreamRef) && has(self.gatherSpec) && has(self.gatherSpec.audit)
+                && self.gatherSpec.audit)'
             - message: audit cannot be enabled when gatherSpec.command is set with
                 the default must-gather image
               rule: '!(!has(self.imageStreamRef) && has(self.gatherSpec) && has(self.gatherSpec.command)
-                && size(self.gatherSpec.command) > 0 && self.gatherSpec.audit)'
+                && size(self.gatherSpec.command) > 0 && has(self.gatherSpec.audit)
+                && self.gatherSpec.audit)'
           status:
             description: MustGatherStatus defines the observed state of MustGather
             properties:

--- a/deploy/crds/operator.openshift.io_mustgathers.yaml
+++ b/deploy/crds/operator.openshift.io_mustgathers.yaml
@@ -43,7 +43,8 @@ spec:
                 description: |-
                   GatherSpec allows overriding the command and/or arguments for the must-gather container
                   (default or custom image from imageStreamRef) and configures time-based collection filters.
-                  Time-based filters (since, sinceTime) and audit apply regardless of ImageStreamRef.
+                  Time-based filters (since, sinceTime) apply regardless of imageStreamRef.
+                  Audit is only allowed with the default image and default gather command (see CRD validation rules).
                 properties:
                   args:
                     description: Args is a string array of arguments passed to the
@@ -54,9 +55,8 @@ spec:
                     type: array
                   audit:
                     description: |-
-                      Audit specifies whether to collect audit logs. This is translated to a signal
-                      or command that can be respected by the default image
-                      or any custom image designed to do so.
+                      Audit requests audit log collection via the default gather entrypoint.
+                      It must be false when imageStreamRef is set or when gatherSpec.command is set without imageStreamRef.
                     type: boolean
                   command:
                     description: |-
@@ -227,6 +227,13 @@ spec:
                   rule: 'has(self.type) && self.type == ''SFTP'' ? has(self.sftp)
                     : !has(self.sftp)'
             type: object
+            x-kubernetes-validations:
+            - message: audit cannot be enabled when using a custom image (imageStreamRef)
+              rule: '!(has(self.imageStreamRef) && has(self.gatherSpec) && self.gatherSpec.audit)'
+            - message: audit cannot be enabled when gatherSpec.command is set with
+                the default must-gather image
+              rule: '!(!has(self.imageStreamRef) && has(self.gatherSpec) && has(self.gatherSpec.command)
+                && size(self.gatherSpec.command) > 0 && self.gatherSpec.audit)'
           status:
             description: MustGatherStatus defines the observed state of MustGather
             properties:

--- a/deploy/crds/operator.openshift.io_mustgathers.yaml
+++ b/deploy/crds/operator.openshift.io_mustgathers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.16.4
   name: mustgathers.operator.openshift.io
 spec:
   group: operator.openshift.io
@@ -41,15 +41,13 @@ spec:
             properties:
               gatherSpec:
                 description: |-
-                  GatherSpec allows overriding the command and/or arguments for the custom must-gather image
-                  and configures time-based collection filters.
-                  The command and args fields are only honored when ImageStreamRef is specified.
+                  GatherSpec allows overriding the command and/or arguments for the must-gather container
+                  (default or custom image from imageStreamRef) and configures time-based collection filters.
                   Time-based filters (since, sinceTime) and audit apply regardless of ImageStreamRef.
                 properties:
                   args:
-                    description: |-
-                      Args is a string array of arguments passed to the custom image's command.
-                      This field is only honored when a custom image IS specified via imageStreamRef.
+                    description: Args is a string array of arguments passed to the
+                      container command.
                     items:
                       type: string
                     maxItems: 256
@@ -62,8 +60,8 @@ spec:
                     type: boolean
                   command:
                     description: |-
-                      Command is a string array representing the entrypoint for the custom image.
-                      This field is only honored when a custom image IS specified via imageStreamRef.
+                      Command is a string array representing the container entrypoint.
+                      When set, it replaces the default gather wrapper for both the default must-gather image and custom images.
                     items:
                       type: string
                     maxItems: 256
@@ -229,12 +227,6 @@ spec:
                   rule: 'has(self.type) && self.type == ''SFTP'' ? has(self.sftp)
                     : !has(self.sftp)'
             type: object
-            x-kubernetes-validations:
-            - message: command and args in gatherSpec can only be set when imageStreamRef
-                is specified
-              rule: '!(has(self.gatherSpec) && ((has(self.gatherSpec.command) && size(self.gatherSpec.command)
-                > 0) || (has(self.gatherSpec.args) && size(self.gatherSpec.args) >
-                0))) || has(self.imageStreamRef)'
           status:
             description: MustGatherStatus defines the observed state of MustGather
             properties:

--- a/deploy/crds/operator.openshift.io_mustgathers.yaml
+++ b/deploy/crds/operator.openshift.io_mustgathers.yaml
@@ -229,11 +229,13 @@ spec:
             type: object
             x-kubernetes-validations:
             - message: audit cannot be enabled when using a custom image (imageStreamRef)
-              rule: '!(has(self.imageStreamRef) && has(self.gatherSpec) && self.gatherSpec.audit)'
+              rule: '!(has(self.imageStreamRef) && has(self.gatherSpec) && has(self.gatherSpec.audit)
+                && self.gatherSpec.audit)'
             - message: audit cannot be enabled when gatherSpec.command is set with
                 the default must-gather image
               rule: '!(!has(self.imageStreamRef) && has(self.gatherSpec) && has(self.gatherSpec.command)
-                && size(self.gatherSpec.command) > 0 && self.gatherSpec.audit)'
+                && size(self.gatherSpec.command) > 0 && has(self.gatherSpec.audit)
+                && self.gatherSpec.audit)'
           status:
             description: MustGatherStatus defines the observed state of MustGather
             properties:

--- a/test/e2e/must_gather_operator_test.go
+++ b/test/e2e/must_gather_operator_test.go
@@ -1295,6 +1295,36 @@ var _ = ginkgo.Describe("MustGather resource", ginkgo.Ordered, func() {
 			Expect(job.Spec.Template.Spec.Containers[0].Image).To(ContainSubstring(customImage))
 		})
 
+		ginkgo.It("should reject creation when gatherSpec.audit is true with imageStreamRef", func() {
+			ginkgo.By("Creating MustGather CR with custom image and audit enabled (invalid per CRD validation)")
+			retain := false
+			mg := &mustgatherv1alpha1.MustGather{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      mustGatherName,
+					Namespace: ns.Name,
+					Labels: map[string]string{
+						"test": nonAdminLabel,
+					},
+				},
+				Spec: mustgatherv1alpha1.MustGatherSpec{
+					ServiceAccountName:          serviceAccount,
+					RetainResourcesOnCompletion: &retain,
+					ImageStreamRef: &mustgatherv1alpha1.ImageStreamTagRef{
+						Name: imageStreamName,
+						Tag:  "latest",
+					},
+					GatherSpec: &mustgatherv1alpha1.GatherSpec{
+						Audit: true,
+					},
+				},
+			}
+			err := nonAdminClient.Create(testCtx, mg)
+			Expect(err).To(HaveOccurred(), "apiserver should reject MustGather with audit and imageStreamRef")
+			Expect(apierrors.IsInvalid(err)).To(BeTrue(), "expected Invalid (422) from CRD validation, got: %v", err)
+			Expect(strings.ToLower(err.Error())).To(ContainSubstring("audit"),
+				"error should describe audit validation failure")
+		})
+
 		ginkgo.It("should fail if the referenced ImageStream does not exist", func() {
 			ginkgo.By("Creating MustGather CR with a non-existent ImageStreamRef")
 			mustGatherCR = createMustGatherCR(mustGatherName, ns.Name, serviceAccount, true, &MustGatherCROptions{


### PR DESCRIPTION
This PR addresses https://redhat.atlassian.net/browse/MG-236 

**Summary**
---------------------
Allow `spec.gatherSpec.command` and `spec.gatherSpec.args` on MustGather when using the default must-gather image (no imageStreamRef). Previously the API rejected this combination via a CEL validation rule. With latest optimization it is necessary to allow command to be coupled with default image as well.


