### PR TITLE
OCPBUGS-78538: fix default service account

### DIFF
--- a/api/v1alpha1/mustgather_types.go
+++ b/api/v1alpha1/mustgather_types.go
@@ -228,7 +228,6 @@ func (m *MustGather) SetConditions(conditions []metav1.Condition) {
 
 // MustGather is the Schema for the mustgathers API
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec) || self.spec == oldSelf.spec",message="spec values are immutable once set"
-// +kubebuilder:validation:XValidation:rule="authorizer.group(”).resource('serviceaccounts').namespace(object.metadata.namespace).name(object.spec.serviceAccountName).check('use').allowed()",message="you are not authorized to use the specified ServiceAccount"
 type MustGather struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1alpha1/mustgather_types.go
+++ b/api/v1alpha1/mustgather_types.go
@@ -27,9 +27,9 @@ import (
 // MustGatherSpec defines the desired state of MustGather
 // +kubebuilder:validation:XValidation:rule="!(has(self.gatherSpec) && ((has(self.gatherSpec.command) && size(self.gatherSpec.command) > 0) || (has(self.gatherSpec.args) && size(self.gatherSpec.args) > 0))) || has(self.imageStreamRef)",message="command and args in gatherSpec can only be set when imageStreamRef is specified"
 type MustGatherSpec struct {
-	// the service account to use to run the must gather job pod, defaults to default
+	// the service account to use to run the must gather job pod, defaults to must-gather-admin
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default:="default"
+	// +kubebuilder:default:="must-gather-admin"
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 
 	// ImageStreamRef specifies a custom image from the allowlist to be used for the

--- a/api/v1alpha1/mustgather_types.go
+++ b/api/v1alpha1/mustgather_types.go
@@ -30,6 +30,7 @@ import (
 type MustGatherSpec struct {
 	// the service account to use to run the must gather job pod, defaults to must-gather-admin
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:default:="must-gather-admin"
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 
@@ -227,6 +228,7 @@ func (m *MustGather) SetConditions(conditions []metav1.Condition) {
 
 // MustGather is the Schema for the mustgathers API
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec) || self.spec == oldSelf.spec",message="spec values are immutable once set"
+// +kubebuilder:validation:XValidation:rule="authorizer.group(”).resource('serviceaccounts').namespace(object.metadata.namespace).name(object.spec.serviceAccountName).check('use').allowed()",message="you are not authorized to use the specified ServiceAccount"
 type MustGather struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/bundle/manifests/tech-preview/operator.openshift.io_mustgathers.yaml
+++ b/bundle/manifests/tech-preview/operator.openshift.io_mustgathers.yaml
@@ -117,6 +117,7 @@ spec:
                 default: must-gather-admin
                 description: the service account to use to run the must gather job
                   pod, defaults to must-gather-admin
+                minLength: 1
                 type: string
               storage:
                 description: |-

--- a/bundle/manifests/tech-preview/operator.openshift.io_mustgathers.yaml
+++ b/bundle/manifests/tech-preview/operator.openshift.io_mustgathers.yaml
@@ -116,9 +116,9 @@ spec:
                   If set to true, resources will be retained. If false or not set, resources will be deleted (default behavior).
                 type: boolean
               serviceAccountName:
-                default: default
+                default: must-gather-admin
                 description: the service account to use to run the must gather job
-                  pod, defaults to default
+                  pod, defaults to must-gather-admin
                 type: string
               storage:
                 description: |-

--- a/controllers/mustgather/mustgather_controller.go
+++ b/controllers/mustgather/mustgather_controller.go
@@ -178,12 +178,11 @@ func (r *MustGatherReconciler) Reconcile(ctx context.Context, request reconcile.
 
 		// Validate that the ServiceAccount exists before creating the Job.
 		// This prevents the Job from being stuck in pending state due to a missing ServiceAccount.
-		// If no ServiceAccount is specified, default to "default" which should exist in all namespaces.
-		// Note: If the "default" SA has been deleted, this validation will catch it and report an error.
+		// If no ServiceAccount is specified, default to "must-gather-admin" which has the required permissions.
 		saName := instance.Spec.ServiceAccountName
 		if saName == "" {
-			saName = "default"
-			log.Info("no serviceAccountName specified, defaulting to 'default'", "namespace", instance.Namespace)
+			saName = "must-gather-admin"
+			log.Info("no serviceAccountName specified, defaulting to 'must-gather-admin'", "namespace", instance.Namespace)
 		}
 		serviceAccount := &corev1.ServiceAccount{}
 		err = r.GetClient().Get(ctx, types.NamespacedName{

--- a/controllers/mustgather/mustgather_controller_test.go
+++ b/controllers/mustgather/mustgather_controller_test.go
@@ -140,7 +140,7 @@ func TestCleanupMustGatherResources(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Name: "mg", Namespace: targetNamespace},
 					Spec:       mustgatherv1alpha1.MustGatherSpec{},
 				}
-				sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: targetNamespace}}
+				sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "must-gather-admin", Namespace: targetNamespace}}
 				return []client.Object{mg, sa}
 			},
 			interceptors: func() interceptClient {
@@ -528,7 +528,7 @@ func TestReconcile(t *testing.T) {
 			name: "reconcile_initialize_mustgather_update_succeeds",
 			setupObjects: func() []client.Object {
 				mg := &mustgatherv1alpha1.MustGather{ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: "ns"}}
-				sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: "ns"}}
+				sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "must-gather-admin", Namespace: "ns"}}
 				return []client.Object{mg, sa}
 			},
 			interceptors:   func() interceptClient { return interceptClient{} },
@@ -540,7 +540,7 @@ func TestReconcile(t *testing.T) {
 			name: "reconcile_initialize_mustgather_update_fails",
 			setupObjects: func() []client.Object {
 				mg := &mustgatherv1alpha1.MustGather{ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: "ns"}}
-				sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: "ns"}}
+				sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "must-gather-admin", Namespace: "ns"}}
 				return []client.Object{mg, sa}
 			},
 			interceptors: func() interceptClient {
@@ -568,7 +568,7 @@ func TestReconcile(t *testing.T) {
 						DeletionTimestamp: &metav1.Time{Time: time.Now()},
 					},
 					Spec: mustgatherv1alpha1.MustGatherSpec{
-						ServiceAccountName: "default",
+						ServiceAccountName: "must-gather-admin",
 						UploadTarget: &mustgatherv1alpha1.UploadTargetSpec{
 							Type: mustgatherv1alpha1.UploadTypeSFTP,
 							SFTP: &mustgatherv1alpha1.SFTPSpec{
@@ -601,7 +601,7 @@ func TestReconcile(t *testing.T) {
 						DeletionTimestamp: &metav1.Time{Time: time.Now()},
 					},
 					Spec: mustgatherv1alpha1.MustGatherSpec{
-						ServiceAccountName: "default",
+						ServiceAccountName: "must-gather-admin",
 						UploadTarget: &mustgatherv1alpha1.UploadTargetSpec{
 							Type: mustgatherv1alpha1.UploadTypeSFTP,
 							SFTP: &mustgatherv1alpha1.SFTPSpec{
@@ -634,10 +634,10 @@ func TestReconcile(t *testing.T) {
 				mg := &mustgatherv1alpha1.MustGather{
 					ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: "ns", Finalizers: []string{mustGatherFinalizer}},
 					Spec: mustgatherv1alpha1.MustGatherSpec{
-						ServiceAccountName: "default",
+						ServiceAccountName: "must-gather-admin",
 					},
 				}
-				sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: "ns"}}
+				sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "must-gather-admin", Namespace: "ns"}}
 				return []client.Object{mg, sa}
 			},
 			interceptors:   func() interceptClient { return interceptClient{} },
@@ -651,10 +651,10 @@ func TestReconcile(t *testing.T) {
 				mg := &mustgatherv1alpha1.MustGather{
 					ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: "ns", Finalizers: []string{mustGatherFinalizer}},
 					Spec: mustgatherv1alpha1.MustGatherSpec{
-						ServiceAccountName: "default",
+						ServiceAccountName: "must-gather-admin",
 					},
 				}
-				sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: "ns"}}
+				sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "must-gather-admin", Namespace: "ns"}}
 				return []client.Object{mg, sa}
 			},
 			interceptors:   func() interceptClient { return interceptClient{} },
@@ -668,11 +668,11 @@ func TestReconcile(t *testing.T) {
 				mg := &mustgatherv1alpha1.MustGather{
 					ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: "ns", Finalizers: []string{mustGatherFinalizer}},
 					Spec: mustgatherv1alpha1.MustGatherSpec{
-						ServiceAccountName: "default",
+						ServiceAccountName: "must-gather-admin",
 					},
 				}
 				userSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "secret", Namespace: "ns"}}
-				sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: "ns"}}
+				sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "must-gather-admin", Namespace: "ns"}}
 				cv := &configv1.ClusterVersion{
 					ObjectMeta: metav1.ObjectMeta{Name: "version"},
 					Status: configv1.ClusterVersionStatus{
@@ -732,7 +732,7 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		{
-			name: "reconcile_empty_service_account_name_defaults_to_default",
+			name: "reconcile_empty_service_account_name_defaults_to_must_gather_admin",
 			setupEnv: func(t *testing.T) {
 				t.Setenv("OPERATOR_IMAGE", "img")
 			},
@@ -740,12 +740,12 @@ func TestReconcile(t *testing.T) {
 				mg := &mustgatherv1alpha1.MustGather{
 					ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: "ns", Finalizers: []string{mustGatherFinalizer}},
 					Spec: mustgatherv1alpha1.MustGatherSpec{
-						// ServiceAccountName is empty, should validate "default" SA exists
+						// ServiceAccountName is empty, should validate "must-gather-admin" SA exists
 						ServiceAccountName: "",
 					},
 				}
-				// Create "default" service account that should be validated
-				sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: "ns"}}
+				// Create "must-gather-admin" service account that should be validated
+				sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "must-gather-admin", Namespace: "ns"}}
 				cv := &configv1.ClusterVersion{
 					ObjectMeta: metav1.ObjectMeta{Name: "version"},
 					Status: configv1.ClusterVersionStatus{
@@ -759,20 +759,20 @@ func TestReconcile(t *testing.T) {
 			expectResult: reconcile.Result{},
 			postTestChecks: func(t *testing.T, cl client.Client) {
 				// Verify the Job was created successfully, proving the validation passed
-				// When ServiceAccountName is empty, the controller validates "default" SA exists
+				// When ServiceAccountName is empty, the controller validates "must-gather-admin" SA exists
 				job := &batchv1.Job{}
 				if err := cl.Get(context.TODO(), types.NamespacedName{Namespace: "ns", Name: "example-mustgather"}, job); err != nil {
-					t.Fatalf("expected job to be created when 'default' service account exists: %v", err)
+					t.Fatalf("expected job to be created when 'must-gather-admin' service account exists: %v", err)
 				}
 				// The job's ServiceAccountName will match the MustGather spec (empty string)
-				// Kubernetes will implicitly use "default" when the field is empty
+				// The controller defaults to "must-gather-admin" for SA validation
 				if job.Spec.Template.Spec.ServiceAccountName != "" {
 					t.Fatalf("expected job ServiceAccountName to be empty (matching spec), got: %q", job.Spec.Template.Spec.ServiceAccountName)
 				}
 			},
 		},
 		{
-			name: "reconcile_empty_service_account_name_default_not_found_calls_manage_error",
+			name: "reconcile_empty_service_account_name_must_gather_admin_not_found_calls_manage_error",
 			setupEnv: func(t *testing.T) {
 				t.Setenv("OPERATOR_IMAGE", "img")
 			},
@@ -780,7 +780,7 @@ func TestReconcile(t *testing.T) {
 				mg := &mustgatherv1alpha1.MustGather{
 					ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: "ns", Finalizers: []string{mustGatherFinalizer}},
 					Spec: mustgatherv1alpha1.MustGatherSpec{
-						// ServiceAccountName is empty, should try to validate "default" SA
+						// ServiceAccountName is empty, should try to validate "must-gather-admin" SA
 						ServiceAccountName: "",
 					},
 				}
@@ -790,7 +790,7 @@ func TestReconcile(t *testing.T) {
 						History: []configv1.UpdateHistory{{State: "Completed", Version: "1.2.3"}},
 					},
 				}
-				// Note: Not creating "default" SA to simulate it being deleted
+				// Note: Not creating "must-gather-admin" SA to simulate it not existing
 				return []client.Object{mg, cv}
 			},
 			interceptors: func() interceptClient { return interceptClient{} },
@@ -826,7 +826,7 @@ func TestReconcile(t *testing.T) {
 				mg := &mustgatherv1alpha1.MustGather{
 					ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: "ns", Finalizers: []string{mustGatherFinalizer}},
 					Spec: mustgatherv1alpha1.MustGatherSpec{
-						ServiceAccountName: "default",
+						ServiceAccountName: "must-gather-admin",
 					},
 				}
 				return []client.Object{mg}
@@ -835,7 +835,7 @@ func TestReconcile(t *testing.T) {
 				return interceptClient{
 					onGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 						// Return a non-NotFound error when getting service account
-						if _, ok := obj.(*corev1.ServiceAccount); ok && key.Name == "default" && key.Namespace == "ns" {
+						if _, ok := obj.(*corev1.ServiceAccount); ok && key.Name == "must-gather-admin" && key.Namespace == "ns" {
 							return errors.New("API server error - failed to get service account")
 						}
 						return nil
@@ -858,7 +858,7 @@ func TestReconcile(t *testing.T) {
 				mg := &mustgatherv1alpha1.MustGather{
 					ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: "ns", Finalizers: []string{mustGatherFinalizer}},
 					Spec: mustgatherv1alpha1.MustGatherSpec{
-						ServiceAccountName: "default",
+						ServiceAccountName: "must-gather-admin",
 						UploadTarget: &mustgatherv1alpha1.UploadTargetSpec{
 							Type: mustgatherv1alpha1.UploadTypeSFTP,
 							SFTP: &mustgatherv1alpha1.SFTPSpec{
@@ -874,7 +874,7 @@ func TestReconcile(t *testing.T) {
 						History: []configv1.UpdateHistory{{State: "Completed", Version: "1.2.3"}},
 					},
 				}
-				sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: "ns"}}
+				sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "must-gather-admin", Namespace: "ns"}}
 				return []client.Object{mg, cv, sa}
 			},
 			interceptors: func() interceptClient { return interceptClient{} },
@@ -898,7 +898,7 @@ func TestReconcile(t *testing.T) {
 				mg := &mustgatherv1alpha1.MustGather{
 					ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: "ns", Finalizers: []string{mustGatherFinalizer}},
 					Spec: mustgatherv1alpha1.MustGatherSpec{
-						ServiceAccountName: "default",
+						ServiceAccountName: "must-gather-admin",
 						UploadTarget: &mustgatherv1alpha1.UploadTargetSpec{
 							Type: mustgatherv1alpha1.UploadTypeSFTP,
 							SFTP: &mustgatherv1alpha1.SFTPSpec{
@@ -914,7 +914,7 @@ func TestReconcile(t *testing.T) {
 						History: []configv1.UpdateHistory{{State: "Completed", Version: "1.2.3"}},
 					},
 				}
-				sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: "ns"}}
+				sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "must-gather-admin", Namespace: "ns"}}
 				return []client.Object{mg, cv, sa}
 			},
 			interceptors: func() interceptClient {
@@ -944,7 +944,7 @@ func TestReconcile(t *testing.T) {
 				mg := &mustgatherv1alpha1.MustGather{
 					ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: "ns", Finalizers: []string{mustGatherFinalizer}},
 					Spec: mustgatherv1alpha1.MustGatherSpec{
-						ServiceAccountName: "default",
+						ServiceAccountName: "must-gather-admin",
 					},
 				}
 				userSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "sec", Namespace: "ns"}}
@@ -956,7 +956,7 @@ func TestReconcile(t *testing.T) {
 				}
 				job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: "ns"}}
 				job.Status.Active = 1
-				sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: "ns"}}
+				sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "must-gather-admin", Namespace: "ns"}}
 				return []client.Object{mg, userSecret, cv, job, sa}
 			},
 			interceptors:   func() interceptClient { return interceptClient{} },
@@ -970,7 +970,7 @@ func TestReconcile(t *testing.T) {
 				mg := &mustgatherv1alpha1.MustGather{
 					ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: operatorNs, Finalizers: []string{mustGatherFinalizer}},
 					Spec: mustgatherv1alpha1.MustGatherSpec{
-						ServiceAccountName:          "default",
+						ServiceAccountName:          "must-gather-admin",
 						RetainResourcesOnCompletion: ToPtr(true),
 					},
 				}
@@ -1001,7 +1001,7 @@ func TestReconcile(t *testing.T) {
 				mg := &mustgatherv1alpha1.MustGather{
 					ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: operatorNs, Finalizers: []string{mustGatherFinalizer}},
 					Spec: mustgatherv1alpha1.MustGatherSpec{
-						ServiceAccountName: "default",
+						ServiceAccountName: "must-gather-admin",
 						UploadTarget: &mustgatherv1alpha1.UploadTargetSpec{
 							Type: mustgatherv1alpha1.UploadTypeSFTP,
 							SFTP: &mustgatherv1alpha1.SFTPSpec{
@@ -1042,7 +1042,7 @@ func TestReconcile(t *testing.T) {
 				mg := &mustgatherv1alpha1.MustGather{
 					ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: "ns", Finalizers: []string{mustGatherFinalizer}},
 					Spec: mustgatherv1alpha1.MustGatherSpec{
-						ServiceAccountName:          "default",
+						ServiceAccountName:          "must-gather-admin",
 						RetainResourcesOnCompletion: ToPtr(true),
 					},
 				}
@@ -1054,7 +1054,7 @@ func TestReconcile(t *testing.T) {
 						History: []configv1.UpdateHistory{{State: "Completed", Version: "1.2.3"}},
 					},
 				}
-				sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: "ns"}}
+				sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "must-gather-admin", Namespace: "ns"}}
 				return []client.Object{mg, cv, job, sa}
 			},
 			interceptors: func() interceptClient { return interceptClient{} },
@@ -1076,7 +1076,7 @@ func TestReconcile(t *testing.T) {
 				mg := &mustgatherv1alpha1.MustGather{
 					ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: operatorNs, Finalizers: []string{mustGatherFinalizer}},
 					Spec: mustgatherv1alpha1.MustGatherSpec{
-						ServiceAccountName: "default",
+						ServiceAccountName: "must-gather-admin",
 					},
 				}
 				userSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "sec", Namespace: operatorNs}}
@@ -1105,7 +1105,7 @@ func TestReconcile(t *testing.T) {
 				mg := &mustgatherv1alpha1.MustGather{
 					ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: operatorNs, Finalizers: []string{mustGatherFinalizer}},
 					Spec: mustgatherv1alpha1.MustGatherSpec{
-						ServiceAccountName: "default",
+						ServiceAccountName: "must-gather-admin",
 					},
 				}
 				userSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "sec", Namespace: operatorNs}}
@@ -1140,7 +1140,7 @@ func TestReconcile(t *testing.T) {
 						DeletionTimestamp: &metav1.Time{Time: time.Now()},
 					},
 					Spec: mustgatherv1alpha1.MustGatherSpec{
-						ServiceAccountName: "default",
+						ServiceAccountName: "must-gather-admin",
 						UploadTarget: &mustgatherv1alpha1.UploadTargetSpec{
 							Type: mustgatherv1alpha1.UploadTypeSFTP,
 							SFTP: &mustgatherv1alpha1.SFTPSpec{
@@ -1177,10 +1177,10 @@ func TestReconcile(t *testing.T) {
 				mg := &mustgatherv1alpha1.MustGather{
 					ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: "ns"},
 					Spec: mustgatherv1alpha1.MustGatherSpec{
-						ServiceAccountName: "default", // Pre-initialized to skip IsInitialized update
+						ServiceAccountName: "must-gather-admin", // Pre-initialized to skip IsInitialized update
 					},
 				}
-				sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: "ns"}}
+				sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "must-gather-admin", Namespace: "ns"}}
 				return []client.Object{mg, sa}
 			},
 			interceptors: func() interceptClient {
@@ -1206,7 +1206,7 @@ func TestReconcile(t *testing.T) {
 				mg := &mustgatherv1alpha1.MustGather{
 					ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: operatorNs, Finalizers: []string{mustGatherFinalizer}},
 					Spec: mustgatherv1alpha1.MustGatherSpec{
-						ServiceAccountName: "default",
+						ServiceAccountName: "must-gather-admin",
 						UploadTarget: &mustgatherv1alpha1.UploadTargetSpec{
 							Type: mustgatherv1alpha1.UploadTypeSFTP,
 							SFTP: &mustgatherv1alpha1.SFTPSpec{
@@ -1254,7 +1254,7 @@ func TestReconcile(t *testing.T) {
 				mg := &mustgatherv1alpha1.MustGather{
 					ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: "ns", Finalizers: []string{mustGatherFinalizer}},
 					Spec: mustgatherv1alpha1.MustGatherSpec{
-						ServiceAccountName: "default",
+						ServiceAccountName: "must-gather-admin",
 						UploadTarget: &mustgatherv1alpha1.UploadTargetSpec{
 							Type: mustgatherv1alpha1.UploadTypeSFTP,
 							SFTP: &mustgatherv1alpha1.SFTPSpec{
@@ -1271,7 +1271,7 @@ func TestReconcile(t *testing.T) {
 						History: []configv1.UpdateHistory{{State: "Completed", Version: "1.2.3"}},
 					},
 				}
-				sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: "ns"}}
+				sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "must-gather-admin", Namespace: "ns"}}
 				return []client.Object{mg, userSecret, cv, sa}
 			},
 			interceptors: func() interceptClient {
@@ -1295,7 +1295,7 @@ func TestReconcile(t *testing.T) {
 				mg := &mustgatherv1alpha1.MustGather{
 					ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: "ns", Finalizers: []string{mustGatherFinalizer}},
 					Spec: mustgatherv1alpha1.MustGatherSpec{
-						ServiceAccountName: "default",
+						ServiceAccountName: "must-gather-admin",
 						UploadTarget: &mustgatherv1alpha1.UploadTargetSpec{
 							Type: mustgatherv1alpha1.UploadTypeSFTP,
 							SFTP: &mustgatherv1alpha1.SFTPSpec{
@@ -1312,7 +1312,7 @@ func TestReconcile(t *testing.T) {
 						History: []configv1.UpdateHistory{{State: "Completed", Version: "1.2.3"}},
 					},
 				}
-				sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: "ns"}}
+				sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "must-gather-admin", Namespace: "ns"}}
 				return []client.Object{mg, userSecret, cv, sa}
 			},
 			interceptors: func() interceptClient {
@@ -1567,15 +1567,15 @@ func createMustGatherSecretObject() *corev1.Secret {
 	}
 }
 
-// createServiceAccountObject creates a default ServiceAccount object for testing purposes.
-// It returns a ServiceAccount named "default" in the openshift-must-gather-operator namespace.
+// createServiceAccountObject creates a ServiceAccount object for testing purposes.
+// It returns a ServiceAccount named "must-gather-admin" in the openshift-must-gather-operator namespace.
 func createServiceAccountObject() *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		TypeMeta: metav1.TypeMeta{
 			Kind: "ServiceAccount",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "default",
+			Name:      "must-gather-admin",
 			Namespace: "openshift-must-gather-operator",
 		},
 	}
@@ -1893,7 +1893,7 @@ func TestSFTPCredentialValidation(t *testing.T) {
 
 			// Create fake client with test objects
 			// Include a ServiceAccount since the controller validates it before SFTP validation
-			sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: tt.mustgather.Namespace}}
+			sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "must-gather-admin", Namespace: tt.mustgather.Namespace}}
 			objects := []client.Object{tt.mustgather, tt.secret, sa}
 			cl := fake.NewClientBuilder().WithScheme(s).WithObjects(objects...).WithStatusSubresource(&mustgatherv1alpha1.MustGather{}).Build()
 

--- a/controllers/mustgather/template_test.go
+++ b/controllers/mustgather/template_test.go
@@ -584,7 +584,7 @@ func Test_getJobTemplate_GatherSpec_BuildsTimeFilter(t *testing.T) {
 			mg := mustgatherv1alpha1.MustGather{
 				ObjectMeta: metav1.ObjectMeta{Name: "mg", Namespace: "ns"},
 				Spec: mustgatherv1alpha1.MustGatherSpec{
-					ServiceAccountName: "default",
+					ServiceAccountName: "must-gather-admin",
 					GatherSpec:         tt.gatherSpec,
 				},
 			}
@@ -657,7 +657,7 @@ func Test_getJobTemplate_ProxyAuditTimeout(t *testing.T) {
 			mg := mustgatherv1alpha1.MustGather{
 				ObjectMeta: metav1.ObjectMeta{Name: "mg", Namespace: "ns"},
 				Spec: mustgatherv1alpha1.MustGatherSpec{
-					ServiceAccountName: "default",
+					ServiceAccountName: "must-gather-admin",
 					MustGatherTimeout:  tt.timeout,
 					GatherSpec: &mustgatherv1alpha1.GatherSpec{
 						Audit: tt.audit,

--- a/deploy/09_must-gather.ValidatingAdmissionPolicy.yaml
+++ b/deploy/09_must-gather.ValidatingAdmissionPolicy.yaml
@@ -1,0 +1,16 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: must-gather-sa-authorization
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups: ["operator.openshift.io"]
+      apiVersions: ["v1alpha1"]
+      resources: ["mustgathers"]
+      operations: ["CREATE"]
+  validations:
+  - expression: "authorizer.group('').resource('serviceaccounts').namespace(object.metadata.namespace).name(object.spec.serviceAccountName).check('use').allowed()"
+    message: "you are not authorized to use the specified ServiceAccount"
+    reason: Forbidden

--- a/deploy/10_must-gather.ValidatingAdmissionPolicyBinding.yaml
+++ b/deploy/10_must-gather.ValidatingAdmissionPolicyBinding.yaml
@@ -1,0 +1,8 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: must-gather-sa-authorization
+spec:
+  policyName: must-gather-sa-authorization
+  validationActions:
+  - Deny

--- a/deploy/crds/operator.openshift.io_mustgathers.yaml
+++ b/deploy/crds/operator.openshift.io_mustgathers.yaml
@@ -312,8 +312,6 @@ spec:
         x-kubernetes-validations:
         - message: spec values are immutable once set
           rule: '!has(oldSelf.spec) || self.spec == oldSelf.spec'
-        - message: you are not authorized to use the specified ServiceAccount
-          rule: authorizer.group('').resource('serviceaccounts').namespace(object.metadata.namespace).name(object.spec.serviceAccountName).check('use').allowed()
     served: true
     storage: true
     subresources:

--- a/deploy/crds/operator.openshift.io_mustgathers.yaml
+++ b/deploy/crds/operator.openshift.io_mustgathers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.16.4
   name: mustgathers.operator.openshift.io
 spec:
   group: operator.openshift.io
@@ -116,9 +116,9 @@ spec:
                   If set to true, resources will be retained. If false or not set, resources will be deleted (default behavior).
                 type: boolean
               serviceAccountName:
-                default: default
+                default: must-gather-admin
                 description: the service account to use to run the must gather job
-                  pod, defaults to default
+                  pod, defaults to must-gather-admin
                 type: string
               storage:
                 description: |-

--- a/deploy/crds/operator.openshift.io_mustgathers.yaml
+++ b/deploy/crds/operator.openshift.io_mustgathers.yaml
@@ -117,6 +117,7 @@ spec:
                 default: must-gather-admin
                 description: the service account to use to run the must gather job
                   pod, defaults to must-gather-admin
+                minLength: 1
                 type: string
               storage:
                 description: |-
@@ -311,6 +312,8 @@ spec:
         x-kubernetes-validations:
         - message: spec values are immutable once set
           rule: '!has(oldSelf.spec) || self.spec == oldSelf.spec'
+        - message: you are not authorized to use the specified ServiceAccount
+          rule: authorizer.group('').resource('serviceaccounts').namespace(object.metadata.namespace).name(object.spec.serviceAccountName).check('use').allowed()
     served: true
     storage: true
     subresources:

--- a/test/e2e/must_gather_operator_test.go
+++ b/test/e2e/must_gather_operator_test.go
@@ -750,60 +750,27 @@ var _ = ginkgo.Describe("MustGather resource", ginkgo.Ordered, func() {
 		ginkgo.It("should report error when ServiceAccount does not exist", func() {
 			mustGatherName := fmt.Sprintf("test-missing-sa-%d", time.Now().UnixNano())
 
-			ginkgo.By("Creating MustGather with non-existent ServiceAccount")
-			mg = createMustGatherCR(mustGatherName, ns.Name, "non-existent-sa-e2e", false, nil)
-
-			ginkgo.By("Verifying MustGather status has error condition")
-			Eventually(func() bool {
-				fetchedMG := &mustgatherv1alpha1.MustGather{}
-				err := adminClient.Get(testCtx, client.ObjectKey{
+			ginkgo.By("Attempting to create MustGather with non-existent ServiceAccount")
+			testMG := &mustgatherv1alpha1.MustGather{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      mustGatherName,
 					Namespace: ns.Name,
-				}, fetchedMG)
-				if err != nil {
-					return false
-				}
-				// Check for error condition with service account message
-				for _, cond := range fetchedMG.Status.Conditions {
-					if cond.Type == "ReconcileError" && cond.Status == metav1.ConditionTrue {
-						if strings.Contains(strings.ToLower(cond.Message), "service account") &&
-							strings.Contains(strings.ToLower(cond.Message), "not found") {
-							ginkgo.GinkgoWriter.Printf("Found expected error condition: %s\n", cond.Message)
-							return true
-						}
-					}
-				}
-				return false
-			}).WithTimeout(1*time.Minute).WithPolling(5*time.Second).Should(BeTrue(),
-				"MustGather status should contain error condition about missing ServiceAccount")
-
-			ginkgo.By("Verifying Job was not created")
-			job := &batchv1.Job{}
-			err := adminClient.Get(testCtx, client.ObjectKey{
-				Name:      mustGatherName,
-				Namespace: ns.Name,
-			}, job)
-			Expect(apierrors.IsNotFound(err)).To(BeTrue(),
-				"Job should not be created when ServiceAccount is missing")
-
-			ginkgo.By("Verifying warning event was generated")
-			events := &corev1.EventList{}
-			err = adminClient.List(testCtx, events, client.InNamespace(ns.Name))
-			Expect(err).NotTo(HaveOccurred())
-
-			foundWarningEvent := false
-			for _, event := range events.Items {
-				if event.InvolvedObject.Name == mustGatherName &&
-					event.Type == corev1.EventTypeWarning &&
-					strings.Contains(strings.ToLower(event.Message), "service account") {
-					foundWarningEvent = true
-					ginkgo.GinkgoWriter.Printf("Found warning event: %s\n", event.Message)
-					break
-				}
+					Labels:    map[string]string{"test": nonAdminLabel},
+				},
+				Spec: mustgatherv1alpha1.MustGatherSpec{
+					ServiceAccountName: "non-existent-sa-e2e",
+				},
 			}
-			Expect(foundWarningEvent).To(BeTrue(), "Warning event should be generated for missing ServiceAccount")
+			err := nonAdminClient.Create(testCtx, testMG)
 
-			ginkgo.GinkgoWriter.Println("ServiceAccount validation correctly prevented Job creation and reported error")
+			ginkgo.By("Verifying admission policy denied the request")
+			Expect(err).To(HaveOccurred(), "Create should fail for unauthorized ServiceAccount")
+			Expect(apierrors.IsForbidden(err)).To(BeTrue(),
+				"Error should be Forbidden, got: %v", err)
+			Expect(err.Error()).To(ContainSubstring("not authorized to use the specified ServiceAccount"),
+				"Error should contain admission policy denial message")
+
+			ginkgo.GinkgoWriter.Println("ValidatingAdmissionPolicy correctly blocked MustGather creation with unauthorized ServiceAccount")
 		})
 
 		ginkgo.It("should enforce ServiceAccount permissions during data collection", func() {

--- a/test/e2e/must_gather_operator_test.go
+++ b/test/e2e/must_gather_operator_test.go
@@ -160,6 +160,10 @@ var _ = ginkgo.Describe("MustGather resource", ginkgo.Ordered, func() {
 		loader.CreateFromFile(testassets.ReadFile, filepath.Join("testdata", "nonadmin-use-serviceaccount-role.yaml"), ns.Name)
 		loader.CreateFromFile(testassets.ReadFile, filepath.Join("testdata", "nonadmin-use-serviceaccount-rolebinding.yaml"), ns.Name)
 
+		ginkgo.By("STEP 8: Creating ValidatingAdmissionPolicy for ServiceAccount authorization")
+		loader.CreateFromFile(testassets.ReadFile, filepath.Join("testdata", "validating-admission-policy.yaml"), "")
+		loader.CreateFromFile(testassets.ReadFile, filepath.Join("testdata", "validating-admission-policy-binding.yaml"), "")
+
 		ginkgo.By("Initializing non-admin client for tests")
 		nonAdminClient = createNonAdminClient()
 
@@ -183,6 +187,8 @@ var _ = ginkgo.Describe("MustGather resource", ginkgo.Ordered, func() {
 		loader.DeleteFromFile(testassets.ReadFile, filepath.Join("testdata", "serviceaccount-clusterrole.yaml"), ns.Name)
 		loader.DeleteFromFile(testassets.ReadFile, filepath.Join("testdata", "serviceaccount-clusterrole-binding.yaml"), ns.Name)
 		loader.DeleteFromFile(testassets.ReadFile, filepath.Join("testdata", "must-gather-admin-clusterrole-binding.yaml"), ns.Name)
+		loader.DeleteFromFile(testassets.ReadFile, filepath.Join("testdata", "validating-admission-policy-binding.yaml"), "")
+		loader.DeleteFromFile(testassets.ReadFile, filepath.Join("testdata", "validating-admission-policy.yaml"), "")
 	})
 
 	// Test Cases
@@ -916,7 +922,7 @@ var _ = ginkgo.Describe("MustGather resource", ginkgo.Ordered, func() {
 				},
 			}
 			err = nonAdminClient.Create(testCtx, mg)
-			Expect(err).To(HaveOccurred(), "Should be rejected by CRD authorizer validation")
+			Expect(err).To(HaveOccurred(), "Should be rejected by ValidatingAdmissionPolicy")
 			Expect(apierrors.IsInvalid(err) || apierrors.IsForbidden(err)).To(BeTrue(),
 				"Error should be Invalid or Forbidden, got: %v", err)
 			Expect(err.Error()).To(ContainSubstring("you are not authorized to use the specified ServiceAccount"),
@@ -925,7 +931,7 @@ var _ = ginkgo.Describe("MustGather resource", ginkgo.Ordered, func() {
 			ginkgo.By("Cleaning up unauthorized ServiceAccount")
 			_ = adminClient.Delete(testCtx, unauthorizedSA)
 
-			ginkgo.GinkgoWriter.Println("CRD authorizer correctly denied MustGather creation for unauthorized ServiceAccount")
+			ginkgo.GinkgoWriter.Println("ValidatingAdmissionPolicy correctly denied MustGather creation for unauthorized ServiceAccount")
 		})
 
 		ginkgo.It("should reject MustGather with explicitly empty serviceAccountName", func() {

--- a/test/e2e/must_gather_operator_test.go
+++ b/test/e2e/must_gather_operator_test.go
@@ -901,7 +901,7 @@ var _ = ginkgo.Describe("MustGather resource", ginkgo.Ordered, func() {
 			ginkgo.GinkgoWriter.Println("ValidatingAdmissionPolicy correctly denied MustGather creation for unauthorized ServiceAccount")
 		})
 
-		ginkgo.It("should apply default serviceAccountName when explicitly set to empty", func() {
+		ginkgo.It("should reject explicitly empty serviceAccountName", func() {
 			ginkgo.By("Creating MustGather CR with explicitly empty serviceAccountName via unstructured client")
 			mgName := fmt.Sprintf("test-empty-sa-%d", time.Now().UnixNano())
 			mgUnstructured := &unstructured.Unstructured{
@@ -919,21 +919,11 @@ var _ = ginkgo.Describe("MustGather resource", ginkgo.Ordered, func() {
 			}
 
 			err := nonAdminClient.Create(testCtx, mgUnstructured)
-			Expect(err).NotTo(HaveOccurred(), "CRD default should replace empty serviceAccountName")
+			Expect(err).To(HaveOccurred(), "Empty serviceAccountName should be rejected by CRD minLength validation")
+			Expect(apierrors.IsInvalid(err)).To(BeTrue(),
+				"Error should be Invalid (422) from CRD validation, got: %v", err)
 
-			ginkgo.By("Verifying API server applied the default serviceAccountName")
-			fetchedMG := &mustgatherv1alpha1.MustGather{}
-			err = adminClient.Get(testCtx, client.ObjectKey{
-				Name:      mgName,
-				Namespace: ns.Name,
-			}, fetchedMG)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(fetchedMG.Spec.ServiceAccountName).To(Equal("must-gather-admin"),
-				"API server should default empty serviceAccountName to 'must-gather-admin'")
-
-			mg = fetchedMG
-
-			ginkgo.GinkgoWriter.Println("CRD default correctly applied 'must-gather-admin' for empty serviceAccountName")
+			ginkgo.GinkgoWriter.Println("CRD minLength validation correctly rejected empty serviceAccountName")
 		})
 	})
 

--- a/test/e2e/must_gather_operator_test.go
+++ b/test/e2e/must_gather_operator_test.go
@@ -27,6 +27,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
@@ -154,6 +155,10 @@ var _ = ginkgo.Describe("MustGather resource", ginkgo.Ordered, func() {
 		ginkgo.By("STEP 6: Creating must-gather-admin ServiceAccount and RBAC (default SA)")
 		loader.CreateFromFile(testassets.ReadFile, filepath.Join("testdata", "must-gather-admin-serviceaccount.yaml"), ns.Name)
 		loader.CreateFromFile(testassets.ReadFile, filepath.Join("testdata", "must-gather-admin-clusterrole-binding.yaml"), ns.Name)
+
+		ginkgo.By("STEP 7: Granting non-admin user 'use' verb on test ServiceAccounts")
+		loader.CreateFromFile(testassets.ReadFile, filepath.Join("testdata", "nonadmin-use-serviceaccount-role.yaml"), ns.Name)
+		loader.CreateFromFile(testassets.ReadFile, filepath.Join("testdata", "nonadmin-use-serviceaccount-rolebinding.yaml"), ns.Name)
 
 		ginkgo.By("Initializing non-admin client for tests")
 		nonAdminClient = createNonAdminClient()
@@ -885,6 +890,66 @@ var _ = ginkgo.Describe("MustGather resource", ginkgo.Ordered, func() {
 			err = nonAdminClient.Update(testCtx, sa)
 			Expect(err).To(HaveOccurred(), "Non-admin should NOT be able to modify ServiceAccounts")
 			Expect(apierrors.IsForbidden(err)).To(BeTrue(), "Should get Forbidden error")
+		})
+
+		ginkgo.It("should deny MustGather creation when user lacks 'use' permission on ServiceAccount", func() {
+			unauthorizedSAName := fmt.Sprintf("must-gather-unauthorized-sa-%d", time.Now().UnixNano())
+
+			ginkgo.By("Creating a ServiceAccount the non-admin user is NOT authorized to use")
+			unauthorizedSA := &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      unauthorizedSAName,
+					Namespace: ns.Name,
+				},
+			}
+			err := adminClient.Create(testCtx, unauthorizedSA)
+			Expect(err).NotTo(HaveOccurred(), "Admin should be able to create ServiceAccount")
+
+			ginkgo.By("Attempting to create MustGather CR with unauthorized ServiceAccount")
+			mg := &mustgatherv1alpha1.MustGather{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("test-authz-deny-%d", time.Now().UnixNano()),
+					Namespace: ns.Name,
+				},
+				Spec: mustgatherv1alpha1.MustGatherSpec{
+					ServiceAccountName: unauthorizedSAName,
+				},
+			}
+			err = nonAdminClient.Create(testCtx, mg)
+			Expect(err).To(HaveOccurred(), "Should be rejected by CRD authorizer validation")
+			Expect(apierrors.IsInvalid(err) || apierrors.IsForbidden(err)).To(BeTrue(),
+				"Error should be Invalid or Forbidden, got: %v", err)
+			Expect(err.Error()).To(ContainSubstring("you are not authorized to use the specified ServiceAccount"),
+				"Error message should indicate authorization failure")
+
+			ginkgo.By("Cleaning up unauthorized ServiceAccount")
+			_ = adminClient.Delete(testCtx, unauthorizedSA)
+
+			ginkgo.GinkgoWriter.Println("CRD authorizer correctly denied MustGather creation for unauthorized ServiceAccount")
+		})
+
+		ginkgo.It("should reject MustGather with explicitly empty serviceAccountName", func() {
+			ginkgo.By("Creating MustGather CR with explicitly empty serviceAccountName via unstructured client")
+			mg := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "operator.openshift.io/v1alpha1",
+					"kind":       "MustGather",
+					"metadata": map[string]interface{}{
+						"name":      fmt.Sprintf("test-empty-sa-%d", time.Now().UnixNano()),
+						"namespace": ns.Name,
+					},
+					"spec": map[string]interface{}{
+						"serviceAccountName": "",
+					},
+				},
+			}
+
+			err := nonAdminClient.Create(testCtx, mg)
+			Expect(err).To(HaveOccurred(), "Should be rejected by MinLength validation")
+			Expect(apierrors.IsInvalid(err)).To(BeTrue(),
+				"Error should be Invalid, got: %v", err)
+
+			ginkgo.GinkgoWriter.Println("CRD MinLength validation correctly rejected empty serviceAccountName")
 		})
 	})
 

--- a/test/e2e/must_gather_operator_test.go
+++ b/test/e2e/must_gather_operator_test.go
@@ -1047,22 +1047,28 @@ var _ = ginkgo.Describe("MustGather resource", ginkgo.Ordered, func() {
 			err := adminClient.Create(testCtx, adminMG)
 			Expect(err).NotTo(HaveOccurred(), "admin should be able to create the initial MustGather CR")
 
-			ginkgo.By("Fetching the created CR to obtain the current resource version")
-			fetchedMG := &mustgatherv1alpha1.MustGather{}
-			err = adminClient.Get(testCtx, client.ObjectKey{
-				Name:      mustGatherName,
-				Namespace: ns.Name,
-			}, fetchedMG)
-			Expect(err).NotTo(HaveOccurred(), "should be able to fetch the created MustGather CR")
-
 			ginkgo.By("Attempting to change serviceAccountName (should be rejected by CRD XValidation immutability rule)")
-			fetchedMG.Spec.ServiceAccountName = "must-gather-admin"
-			err = adminClient.Update(testCtx, fetchedMG)
-			Expect(err).To(HaveOccurred(),
+			var updateErr error
+			Eventually(func() bool {
+				fetchedMG := &mustgatherv1alpha1.MustGather{}
+				if err := adminClient.Get(testCtx, client.ObjectKey{
+					Name:      mustGatherName,
+					Namespace: ns.Name,
+				}, fetchedMG); err != nil {
+					return false
+				}
+				fetchedMG.Spec.ServiceAccountName = "must-gather-admin"
+				updateErr = adminClient.Update(testCtx, fetchedMG)
+				// Retry on conflict (controller may be updating finalizers/status concurrently)
+				return !apierrors.IsConflict(updateErr)
+			}).WithTimeout(30*time.Second).WithPolling(2*time.Second).Should(BeTrue(),
+				"should eventually get past conflict errors")
+
+			Expect(updateErr).To(HaveOccurred(),
 				"update changing serviceAccountName should be rejected by CRD immutability rule")
-			Expect(apierrors.IsInvalid(err)).To(BeTrue(),
-				"error should be Invalid (422) from CRD XValidation immutability rule, got: %v", err)
-			Expect(err.Error()).To(ContainSubstring("immutable"),
+			Expect(apierrors.IsInvalid(updateErr)).To(BeTrue(),
+				"error should be Invalid (422) from CRD XValidation immutability rule, got: %v", updateErr)
+			Expect(updateErr.Error()).To(ContainSubstring("immutable"),
 				"error message should reference the immutability constraint")
 
 			ginkgo.By("Cleaning up the MustGather CR")

--- a/test/e2e/must_gather_operator_test.go
+++ b/test/e2e/must_gather_operator_test.go
@@ -151,6 +151,10 @@ var _ = ginkgo.Describe("MustGather resource", ginkgo.Ordered, func() {
 		loader.CreateFromFile(testassets.ReadFile, filepath.Join("testdata", "serviceaccount-clusterrole.yaml"), ns.Name)
 		loader.CreateFromFile(testassets.ReadFile, filepath.Join("testdata", "serviceaccount-clusterrole-binding.yaml"), ns.Name)
 
+		ginkgo.By("STEP 6: Creating must-gather-admin ServiceAccount and RBAC (default SA)")
+		loader.CreateFromFile(testassets.ReadFile, filepath.Join("testdata", "must-gather-admin-serviceaccount.yaml"), ns.Name)
+		loader.CreateFromFile(testassets.ReadFile, filepath.Join("testdata", "must-gather-admin-clusterrole-binding.yaml"), ns.Name)
+
 		ginkgo.By("Initializing non-admin client for tests")
 		nonAdminClient = createNonAdminClient()
 
@@ -173,6 +177,7 @@ var _ = ginkgo.Describe("MustGather resource", ginkgo.Ordered, func() {
 		loader.DeleteFromFile(testassets.ReadFile, filepath.Join("testdata", "nonadmin-clusterrole-binding.yaml"), ns.Name)
 		loader.DeleteFromFile(testassets.ReadFile, filepath.Join("testdata", "serviceaccount-clusterrole.yaml"), ns.Name)
 		loader.DeleteFromFile(testassets.ReadFile, filepath.Join("testdata", "serviceaccount-clusterrole-binding.yaml"), ns.Name)
+		loader.DeleteFromFile(testassets.ReadFile, filepath.Join("testdata", "must-gather-admin-clusterrole-binding.yaml"), ns.Name)
 	})
 
 	// Test Cases
@@ -694,6 +699,41 @@ var _ = ginkgo.Describe("MustGather resource", ginkgo.Ordered, func() {
 				_ = nonAdminClient.Delete(testCtx, mg)
 				mg = nil
 			}
+		})
+
+		ginkgo.It("should default serviceAccountName to must-gather-admin when not specified", func() {
+			mustGatherName := fmt.Sprintf("test-default-sa-%d", time.Now().UnixNano())
+
+			ginkgo.By("Creating MustGather CR without specifying serviceAccountName")
+			// Pass empty string for serviceAccountName — with omitempty, this field
+			// will be omitted from JSON serialization, and the API server will apply
+			// the CRD default "must-gather-admin"
+			mg = createMustGatherCR(mustGatherName, ns.Name, "", false, nil)
+
+			ginkgo.By("Verifying API server applied the default serviceAccountName")
+			fetchedMG := &mustgatherv1alpha1.MustGather{}
+			err := adminClient.Get(testCtx, client.ObjectKey{
+				Name:      mustGatherName,
+				Namespace: ns.Name,
+			}, fetchedMG)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(fetchedMG.Spec.ServiceAccountName).To(Equal("must-gather-admin"),
+				"API server should default serviceAccountName to 'must-gather-admin'")
+
+			ginkgo.By("Verifying Job is created with the default ServiceAccount")
+			job := &batchv1.Job{}
+			Eventually(func() error {
+				return adminClient.Get(testCtx, client.ObjectKey{
+					Name:      mustGatherName,
+					Namespace: ns.Name,
+				}, job)
+			}).WithTimeout(2*time.Minute).WithPolling(5*time.Second).Should(Succeed(),
+				"Job should be created when default must-gather-admin SA exists")
+
+			Expect(job.Spec.Template.Spec.ServiceAccountName).To(Equal("must-gather-admin"),
+				"Job pod spec should use must-gather-admin ServiceAccount")
+
+			ginkgo.GinkgoWriter.Println("Default serviceAccountName correctly applied as 'must-gather-admin'")
 		})
 
 		ginkgo.It("should report error when ServiceAccount does not exist", func() {

--- a/test/e2e/must_gather_operator_test.go
+++ b/test/e2e/must_gather_operator_test.go
@@ -901,14 +901,15 @@ var _ = ginkgo.Describe("MustGather resource", ginkgo.Ordered, func() {
 			ginkgo.GinkgoWriter.Println("ValidatingAdmissionPolicy correctly denied MustGather creation for unauthorized ServiceAccount")
 		})
 
-		ginkgo.It("should reject MustGather with explicitly empty serviceAccountName", func() {
+		ginkgo.It("should apply default serviceAccountName when explicitly set to empty", func() {
 			ginkgo.By("Creating MustGather CR with explicitly empty serviceAccountName via unstructured client")
-			mg := &unstructured.Unstructured{
+			mgName := fmt.Sprintf("test-empty-sa-%d", time.Now().UnixNano())
+			mgUnstructured := &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"apiVersion": "operator.openshift.io/v1alpha1",
 					"kind":       "MustGather",
 					"metadata": map[string]interface{}{
-						"name":      fmt.Sprintf("test-empty-sa-%d", time.Now().UnixNano()),
+						"name":      mgName,
 						"namespace": ns.Name,
 					},
 					"spec": map[string]interface{}{
@@ -917,12 +918,22 @@ var _ = ginkgo.Describe("MustGather resource", ginkgo.Ordered, func() {
 				},
 			}
 
-			err := nonAdminClient.Create(testCtx, mg)
-			Expect(err).To(HaveOccurred(), "Should be rejected by MinLength validation")
-			Expect(apierrors.IsInvalid(err)).To(BeTrue(),
-				"Error should be Invalid, got: %v", err)
+			err := nonAdminClient.Create(testCtx, mgUnstructured)
+			Expect(err).NotTo(HaveOccurred(), "CRD default should replace empty serviceAccountName")
 
-			ginkgo.GinkgoWriter.Println("CRD MinLength validation correctly rejected empty serviceAccountName")
+			ginkgo.By("Verifying API server applied the default serviceAccountName")
+			fetchedMG := &mustgatherv1alpha1.MustGather{}
+			err = adminClient.Get(testCtx, client.ObjectKey{
+				Name:      mgName,
+				Namespace: ns.Name,
+			}, fetchedMG)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(fetchedMG.Spec.ServiceAccountName).To(Equal("must-gather-admin"),
+				"API server should default empty serviceAccountName to 'must-gather-admin'")
+
+			mg = fetchedMG
+
+			ginkgo.GinkgoWriter.Println("CRD default correctly applied 'must-gather-admin' for empty serviceAccountName")
 		})
 	})
 

--- a/test/e2e/must_gather_operator_test.go
+++ b/test/e2e/must_gather_operator_test.go
@@ -64,6 +64,7 @@ const (
 	nonAdminCRRoleName = "must-gather-nonadmin-clusterrole"
 	serviceAccount     = "must-gather-serviceaccount"
 	nonAdminLabel      = "support-log-gather"
+	nonAdminUserNoUse  = "must-gather-nonadmin-user-no-use"
 
 	// Operator constants
 	operatorNamespace  = "must-gather-operator"
@@ -100,6 +101,7 @@ var (
 	adminClient       client.Client
 	nonAdminClient    client.Client
 	nonAdminClientset *kubernetes.Clientset
+	noUseClient       client.Client
 	operatorImage     string
 	setupComplete     bool
 )
@@ -164,8 +166,34 @@ var _ = ginkgo.Describe("MustGather resource", ginkgo.Ordered, func() {
 		loader.CreateFromFile(testassets.ReadFile, filepath.Join("testdata", "validating-admission-policy.yaml"), "")
 		loader.CreateFromFile(testassets.ReadFile, filepath.Join("testdata", "validating-admission-policy-binding.yaml"), "")
 
+		ginkgo.By("STEP 9: Creating RoleBinding for no-use test user (MustGather CRUD, no 'use' on any SA)")
+		noUseRB := &rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "must-gather-nonadmin-no-use-rolebinding",
+				Namespace: ns.Name,
+				Labels:    map[string]string{"test": nonAdminLabel},
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: "rbac.authorization.k8s.io",
+				Kind:     "ClusterRole",
+				Name:     nonAdminCRRoleName,
+			},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind:     "User",
+					Name:     nonAdminUserNoUse,
+					APIGroup: "rbac.authorization.k8s.io",
+				},
+			},
+		}
+		err = adminClient.Create(testCtx, noUseRB)
+		Expect(err).NotTo(HaveOccurred(), "Failed to create no-use user RoleBinding")
+
 		ginkgo.By("Initializing non-admin client for tests")
 		nonAdminClient = createNonAdminClient()
+
+		ginkgo.By("Initializing no-use client (user without 'use' permission on any ServiceAccount)")
+		noUseClient = createNoUseClient()
 
 		setupComplete = true
 		ginkgo.GinkgoWriter.Println("Admin setup complete - RBAC and ServiceAccount configured")
@@ -727,7 +755,7 @@ var _ = ginkgo.Describe("MustGather resource", ginkgo.Ordered, func() {
 				Name:      mustGatherName,
 				Namespace: ns.Name,
 			}, fetchedMG)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred(), "admin should be able to fetch the MustGather CR")
 			Expect(fetchedMG.Spec.ServiceAccountName).To(Equal("must-gather-admin"),
 				"API server should default serviceAccountName to 'must-gather-admin'")
 
@@ -747,7 +775,7 @@ var _ = ginkgo.Describe("MustGather resource", ginkgo.Ordered, func() {
 			ginkgo.GinkgoWriter.Println("Default serviceAccountName correctly applied as 'must-gather-admin'")
 		})
 
-		ginkgo.It("should report error when ServiceAccount does not exist", func() {
+		ginkgo.It("should deny creation when user lacks use permission on ServiceAccount", func() {
 			mustGatherName := fmt.Sprintf("test-missing-sa-%d", time.Now().UnixNano())
 
 			ginkgo.By("Attempting to create MustGather with non-existent ServiceAccount")
@@ -793,10 +821,12 @@ var _ = ginkgo.Describe("MustGather resource", ginkgo.Ordered, func() {
 					return true
 				}
 				return false
-			}).WithTimeout(2 * time.Minute).WithPolling(5 * time.Second).Should(BeTrue())
+			}).WithTimeout(2*time.Minute).WithPolling(5*time.Second).Should(BeTrue(),
+				"gather Pod should be created and running before checking security constraints")
 
 			ginkgo.By("Verifying Pod has no privilege escalation")
-			Expect(gatherPod.Spec.ServiceAccountName).To(Equal(serviceAccount))
+			Expect(gatherPod.Spec.ServiceAccountName).To(Equal(serviceAccount),
+				"Pod should use the ServiceAccount specified in MustGather CR")
 
 			// Check that pod doesn't request privileged mode
 			for _, container := range gatherPod.Spec.Containers {
@@ -924,6 +954,203 @@ var _ = ginkgo.Describe("MustGather resource", ginkgo.Ordered, func() {
 				"Error should be Invalid (422) from CRD validation, got: %v", err)
 
 			ginkgo.GinkgoWriter.Println("CRD minLength validation correctly rejected empty serviceAccountName")
+		})
+
+		ginkgo.It("should allow admin user to create MustGather CR with must-gather-admin SA", func() {
+			mustGatherName := fmt.Sprintf("test-admin-create-%d", time.Now().UnixNano())
+
+			ginkgo.By("Creating MustGather CR as admin with must-gather-admin ServiceAccount")
+			adminMG := &mustgatherv1alpha1.MustGather{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      mustGatherName,
+					Namespace: ns.Name,
+					Labels:    map[string]string{"test": nonAdminLabel},
+				},
+				Spec: mustgatherv1alpha1.MustGatherSpec{
+					ServiceAccountName: "must-gather-admin",
+				},
+			}
+			err := adminClient.Create(testCtx, adminMG)
+			Expect(err).NotTo(HaveOccurred(),
+				"admin should be able to create MustGather CR with must-gather-admin SA")
+
+			ginkgo.By("Verifying CR was persisted with correct serviceAccountName")
+			fetchedMG := &mustgatherv1alpha1.MustGather{}
+			err = adminClient.Get(testCtx, client.ObjectKey{
+				Name:      mustGatherName,
+				Namespace: ns.Name,
+			}, fetchedMG)
+			Expect(err).NotTo(HaveOccurred(), "admin should be able to fetch the created MustGather CR")
+			Expect(fetchedMG.Spec.ServiceAccountName).To(Equal("must-gather-admin"),
+				"serviceAccountName in persisted CR should be must-gather-admin")
+
+			ginkgo.By("Cleaning up admin-created MustGather CR")
+			err = adminClient.Delete(testCtx, adminMG)
+			Expect(err).NotTo(HaveOccurred(), "admin should be able to delete the MustGather CR")
+
+			Eventually(func() bool {
+				err := adminClient.Get(testCtx, client.ObjectKey{
+					Name:      mustGatherName,
+					Namespace: ns.Name,
+				}, &mustgatherv1alpha1.MustGather{})
+				return apierrors.IsNotFound(err)
+			}).WithTimeout(2*time.Minute).WithPolling(5*time.Second).Should(BeTrue(),
+				"admin-created MustGather CR should be fully deleted")
+
+			ginkgo.GinkgoWriter.Println("Admin user correctly allowed to create MustGather CR with must-gather-admin SA")
+		})
+
+		ginkgo.It("should deny non-admin user when serviceAccountName is omitted and default SA applies", func() {
+			mustGatherName := fmt.Sprintf("test-nonadmin-omit-sa-%d", time.Now().UnixNano())
+
+			ginkgo.By("Creating MustGather CR with omitted serviceAccountName via no-use client")
+			// Use unstructured with an empty spec so the field is truly absent from the JSON payload.
+			// The API server will apply the CRD default "must-gather-admin" before evaluating the VAP.
+			mgUnstructured := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "operator.openshift.io/v1alpha1",
+					"kind":       "MustGather",
+					"metadata": map[string]interface{}{
+						"name":      mustGatherName,
+						"namespace": ns.Name,
+					},
+					"spec": map[string]interface{}{},
+				},
+			}
+			err := noUseClient.Create(testCtx, mgUnstructured)
+
+			ginkgo.By("Verifying ValidatingAdmissionPolicy denied the request")
+			Expect(err).To(HaveOccurred(),
+				"non-admin without 'use' on must-gather-admin should be denied when serviceAccountName is omitted")
+			Expect(apierrors.IsForbidden(err)).To(BeTrue(),
+				"error should be Forbidden from ValidatingAdmissionPolicy, got: %v", err)
+			Expect(err.Error()).To(ContainSubstring("not authorized to use the specified ServiceAccount"),
+				"error message should describe authorization failure for the default SA")
+
+			ginkgo.GinkgoWriter.Println("ValidatingAdmissionPolicy correctly denied non-admin without 'use' when serviceAccountName was omitted")
+		})
+
+		ginkgo.It("should reject update that changes serviceAccountName after creation", func() {
+			mustGatherName := fmt.Sprintf("test-immutable-sa-%d", time.Now().UnixNano())
+
+			ginkgo.By("Creating MustGather CR as admin")
+			adminMG := &mustgatherv1alpha1.MustGather{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      mustGatherName,
+					Namespace: ns.Name,
+					Labels:    map[string]string{"test": nonAdminLabel},
+				},
+				Spec: mustgatherv1alpha1.MustGatherSpec{
+					ServiceAccountName: serviceAccount,
+				},
+			}
+			err := adminClient.Create(testCtx, adminMG)
+			Expect(err).NotTo(HaveOccurred(), "admin should be able to create the initial MustGather CR")
+
+			ginkgo.By("Fetching the created CR to obtain the current resource version")
+			fetchedMG := &mustgatherv1alpha1.MustGather{}
+			err = adminClient.Get(testCtx, client.ObjectKey{
+				Name:      mustGatherName,
+				Namespace: ns.Name,
+			}, fetchedMG)
+			Expect(err).NotTo(HaveOccurred(), "should be able to fetch the created MustGather CR")
+
+			ginkgo.By("Attempting to change serviceAccountName (should be rejected by CRD XValidation immutability rule)")
+			fetchedMG.Spec.ServiceAccountName = "must-gather-admin"
+			err = adminClient.Update(testCtx, fetchedMG)
+			Expect(err).To(HaveOccurred(),
+				"update changing serviceAccountName should be rejected by CRD immutability rule")
+			Expect(apierrors.IsInvalid(err)).To(BeTrue(),
+				"error should be Invalid (422) from CRD XValidation immutability rule, got: %v", err)
+			Expect(err.Error()).To(ContainSubstring("immutable"),
+				"error message should reference the immutability constraint")
+
+			ginkgo.By("Cleaning up the MustGather CR")
+			freshMG := &mustgatherv1alpha1.MustGather{}
+			if getErr := adminClient.Get(testCtx, client.ObjectKey{
+				Name:      mustGatherName,
+				Namespace: ns.Name,
+			}, freshMG); getErr == nil {
+				_ = adminClient.Delete(testCtx, freshMG)
+			}
+
+			ginkgo.GinkgoWriter.Println("CRD XValidation correctly rejected serviceAccountName change after creation")
+		})
+
+		ginkgo.It("should set ReconcileError status when ServiceAccount does not exist (admin creates CR)", func() {
+			mustGatherName := fmt.Sprintf("test-nonexistent-sa-ctrl-%d", time.Now().UnixNano())
+			nonExistentSA := "non-existent-sa-ctrl-test"
+
+			ginkgo.By("Creating MustGather CR as admin with a non-existent ServiceAccount")
+			// Admin has wildcard RBAC so the ValidatingAdmissionPolicy passes.
+			// The controller then tries to look up the SA and sets ReconcileError status on failure.
+			adminMG := &mustgatherv1alpha1.MustGather{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      mustGatherName,
+					Namespace: ns.Name,
+					Labels:    map[string]string{"test": nonAdminLabel},
+				},
+				Spec: mustgatherv1alpha1.MustGatherSpec{
+					ServiceAccountName: nonExistentSA,
+				},
+			}
+			err := adminClient.Create(testCtx, adminMG)
+			Expect(err).NotTo(HaveOccurred(),
+				"admin should be able to create MustGather CR (ValidatingAdmissionPolicy passes for admin)")
+
+			ginkgo.By("Waiting for controller to detect the missing SA and set Failed status")
+			fetchedMG := &mustgatherv1alpha1.MustGather{}
+			Eventually(func(g Gomega) {
+				g.Expect(adminClient.Get(testCtx, client.ObjectKey{
+					Name:      mustGatherName,
+					Namespace: ns.Name,
+				}, fetchedMG)).To(Succeed(), "should be able to fetch MustGather CR")
+				g.Expect(fetchedMG.Status.Completed).To(BeTrue(),
+					"MustGather should be marked Completed (with failure) when SA does not exist")
+				g.Expect(fetchedMG.Status.Status).To(Equal("Failed"),
+					"MustGather status should be Failed when SA does not exist")
+			}).WithTimeout(2*time.Minute).WithPolling(5*time.Second).Should(Succeed(),
+				"controller should set Failed status for non-existent ServiceAccount")
+
+			ginkgo.By("Verifying ReconcileError condition is set with correct reason")
+			var reconcileErrCondition *metav1.Condition
+			for i := range fetchedMG.Status.Conditions {
+				if fetchedMG.Status.Conditions[i].Type == "ReconcileError" {
+					reconcileErrCondition = &fetchedMG.Status.Conditions[i]
+					break
+				}
+			}
+			Expect(reconcileErrCondition).NotTo(BeNil(),
+				"ReconcileError condition should be present when SA does not exist")
+			Expect(reconcileErrCondition.Status).To(Equal(metav1.ConditionTrue),
+				"ReconcileError condition status should be True")
+			Expect(reconcileErrCondition.Reason).To(Equal("ValidationFailed"),
+				"ReconcileError condition reason should be ValidationFailed")
+
+			ginkgo.By("Verifying no Job was created for the failed MustGather")
+			Consistently(func() bool {
+				err := adminClient.Get(testCtx, client.ObjectKey{
+					Name:      mustGatherName,
+					Namespace: ns.Name,
+				}, &batchv1.Job{})
+				return apierrors.IsNotFound(err)
+			}).WithTimeout(30*time.Second).WithPolling(5*time.Second).Should(BeTrue(),
+				"no Job should be created when the ServiceAccount does not exist")
+
+			ginkgo.By("Cleaning up the MustGather CR")
+			err = adminClient.Delete(testCtx, adminMG)
+			Expect(err).NotTo(HaveOccurred(), "admin should be able to delete the MustGather CR")
+
+			Eventually(func() bool {
+				err := adminClient.Get(testCtx, client.ObjectKey{
+					Name:      mustGatherName,
+					Namespace: ns.Name,
+				}, &mustgatherv1alpha1.MustGather{})
+				return apierrors.IsNotFound(err)
+			}).WithTimeout(2*time.Minute).WithPolling(5*time.Second).Should(BeTrue(),
+				"MustGather CR should be fully deleted after cleanup")
+
+			ginkgo.GinkgoWriter.Printf("Controller correctly set ReconcileError status for non-existent SA: %s\n", nonExistentSA)
 		})
 	})
 
@@ -1746,6 +1973,20 @@ func createNonAdminClient() client.Client {
 	Expect(err).NotTo(HaveOccurred(), "Failed to create non-admin clientset")
 
 	ginkgo.GinkgoWriter.Printf("Created impersonated client for user: %s\n", nonAdminUser)
+	return c
+}
+
+func createNoUseClient() client.Client {
+	ginkgo.By("Creating impersonated no-use client")
+	noUseConfig := rest.CopyConfig(adminRestConfig)
+	noUseConfig.Impersonate = rest.ImpersonationConfig{
+		UserName: nonAdminUserNoUse,
+	}
+
+	c, err := client.New(noUseConfig, client.Options{Scheme: testScheme})
+	Expect(err).NotTo(HaveOccurred(), "Failed to create no-use impersonation client")
+
+	ginkgo.GinkgoWriter.Printf("Created impersonated client for user: %s\n", nonAdminUserNoUse)
 	return c
 }
 

--- a/test/e2e/testdata/must-gather-admin-clusterrole-binding.yaml
+++ b/test/e2e/testdata/must-gather-admin-clusterrole-binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: must-gather-admin-e2e-binding
+  labels:
+    test: non-admin-must-gather-e2e
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: must-gather-admin
+subjects:
+  - kind: ServiceAccount
+    name: must-gather-admin

--- a/test/e2e/testdata/must-gather-admin-serviceaccount.yaml
+++ b/test/e2e/testdata/must-gather-admin-serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: must-gather-admin
+  # namespace will be set at runtime
+  labels:
+    test: non-admin-must-gather-e2e

--- a/test/e2e/testdata/nonadmin-use-serviceaccount-role.yaml
+++ b/test/e2e/testdata/nonadmin-use-serviceaccount-role.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: must-gather-nonadmin-use-sa
+  # namespace will be set at runtime
+  labels:
+    test: non-admin-must-gather-e2e
+rules:
+- apiGroups: [""]
+  resources: ["serviceaccounts"]
+  resourceNames: ["must-gather-serviceaccount", "must-gather-admin"]
+  verbs: ["use"]

--- a/test/e2e/testdata/nonadmin-use-serviceaccount-rolebinding.yaml
+++ b/test/e2e/testdata/nonadmin-use-serviceaccount-rolebinding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: must-gather-nonadmin-use-sa-binding
+  # namespace will be set at runtime
+  labels:
+    test: non-admin-must-gather-e2e
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: must-gather-nonadmin-use-sa
+subjects:
+- kind: User
+  name: must-gather-nonadmin-user
+  apiGroup: rbac.authorization.k8s.io

--- a/test/e2e/testdata/validating-admission-policy-binding.yaml
+++ b/test/e2e/testdata/validating-admission-policy-binding.yaml
@@ -1,0 +1,10 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: must-gather-sa-authorization
+  labels:
+    test: non-admin-must-gather-e2e
+spec:
+  policyName: must-gather-sa-authorization
+  validationActions:
+  - Deny

--- a/test/e2e/testdata/validating-admission-policy.yaml
+++ b/test/e2e/testdata/validating-admission-policy.yaml
@@ -1,0 +1,18 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: must-gather-sa-authorization
+  labels:
+    test: non-admin-must-gather-e2e
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups: ["operator.openshift.io"]
+      apiVersions: ["v1alpha1"]
+      resources: ["mustgathers"]
+      operations: ["CREATE"]
+  validations:
+  - expression: "authorizer.group('').resource('serviceaccounts').namespace(object.metadata.namespace).name(object.spec.serviceAccountName).check('use').allowed()"
+    message: "you are not authorized to use the specified ServiceAccount"
+    reason: Forbidden

--- a/test/e2e/testdata/validating-admission-policy.yaml
+++ b/test/e2e/testdata/validating-admission-policy.yaml
@@ -13,6 +13,6 @@ spec:
       resources: ["mustgathers"]
       operations: ["CREATE"]
   validations:
-  - expression: "!has(object.spec.serviceAccountName) || object.spec.serviceAccountName == '' || authorizer.group('').resource('serviceaccounts').namespace(object.metadata.namespace).name(object.spec.serviceAccountName).check('use').allowed()"
+  - expression: "!has(object.spec.serviceAccountName) || authorizer.group('').resource('serviceaccounts').namespace(object.metadata.namespace).name(object.spec.serviceAccountName).check('use').allowed()"
     message: "you are not authorized to use the specified ServiceAccount"
     reason: Forbidden

--- a/test/e2e/testdata/validating-admission-policy.yaml
+++ b/test/e2e/testdata/validating-admission-policy.yaml
@@ -13,6 +13,6 @@ spec:
       resources: ["mustgathers"]
       operations: ["CREATE"]
   validations:
-  - expression: "authorizer.group('').resource('serviceaccounts').namespace(object.metadata.namespace).name(object.spec.serviceAccountName).check('use').allowed()"
+  - expression: "!has(object.spec.serviceAccountName) || object.spec.serviceAccountName == '' || authorizer.group('').resource('serviceaccounts').namespace(object.metadata.namespace).name(object.spec.serviceAccountName).check('use').allowed()"
     message: "you are not authorized to use the specified ServiceAccount"
     reason: Forbidden

--- a/test/e2e/testdata/validating-admission-policy.yaml
+++ b/test/e2e/testdata/validating-admission-policy.yaml
@@ -13,6 +13,6 @@ spec:
       resources: ["mustgathers"]
       operations: ["CREATE"]
   validations:
-  - expression: "!has(object.spec.serviceAccountName) || authorizer.group('').resource('serviceaccounts').namespace(object.metadata.namespace).name(object.spec.serviceAccountName).check('use').allowed()"
+  - expression: "!has(object.spec.serviceAccountName) || object.spec.serviceAccountName == '' || authorizer.group('').resource('serviceaccounts').namespace(object.metadata.namespace).name(object.spec.serviceAccountName).check('use').allowed()"
     message: "you are not authorized to use the specified ServiceAccount"
     reason: Forbidden


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Default ServiceAccount changed from "default" to "must-gather-admin"
  * CRD/schema updated to reflect new default and require a non-empty ServiceAccount name
  * Added admission validation to deny unauthorized ServiceAccount references and supporting RBAC test manifests

* **Tests**
  * Updated unit tests for the new default
  * Added E2E tests for API-server defaulting, Job usage of must-gather-admin, authorization failures, and empty-string validation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->