### PR TITLE
OCPBUGS-79069 - fix the since and sinceTime validation issue

### DIFF
--- a/api/v1alpha1/mustgather_types.go
+++ b/api/v1alpha1/mustgather_types.go
@@ -71,6 +71,9 @@ type MustGatherSpec struct {
 
 // GatherSpec allows specifying the execution details for a must-gather run and the collection behavior.
 // +kubebuilder:validation:XValidation:rule="!(has(self.since) && has(self.sinceTime))",message="only one of since or sinceTime may be specified"
+// +kubebuilder:validation:XValidation:rule="!has(self.since) || !self.since.startsWith(\"-\")",message="since must be a non-negative duration string"
+// +kubebuilder:validation:XValidation:rule="!has(self.since) || self.since.startsWith(\"-\") || self.since.matches(r'^\\+?(([0-9]+(\\.[0-9]*)?|\\.[0-9]+)(ns|µs|us|ms|s|m|h))+$')",message="since may only use these duration suffixes: ns, us, µs, ms, s, m, h (e.g. 2h, 30m, 168h for one week)."
+// +kubebuilder:validation:XValidation:rule="!has(self.sinceTime) || self.sinceTime.matches(r'^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?(Z|[+-]\\d{2}:\\d{2})$')",message="sinceTime must be in RFC3339 format."
 type GatherSpec struct {
 	// +kubebuilder:validation:Optional
 	// Audit requests audit log collection via the default gather entrypoint.
@@ -90,18 +93,19 @@ type GatherSpec struct {
 	// +kubebuilder:validation:Items:MaxLength=256
 	Args []string `json:"args,omitempty"`
 
-	// Since only returns logs newer than a relative duration like "2h" or "30m".
+	// Since only returns logs newer than a relative duration (e.g. 2h, 30m, 168h for one week). Must be non-negative.
+	// Allowed units are ns, us, µs, ms, s, m, and h.
 	// This is passed to the must-gather script to filter log collection.
 	// Only one of since or sinceTime may be specified.
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:validation:Format=duration
 	Since *metav1.Duration `json:"since,omitempty"`
 
-	// SinceTime only returns logs after a specific date/time (RFC3339 format).
+	// SinceTime only returns logs after a specific instant. Use RFC3339 with uppercase T and Z or a zone offset
+	// (e.g. 2026-02-02T00:00:00Z). Must not be after the current time when the operator reconciles the MustGather
+	// (CRD CEL cannot access metadata.creationTimestamp or a wall clock; validation is done in the controller).
 	// This is passed to the must-gather script to filter log collection.
 	// Only one of since or sinceTime may be specified.
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:validation:Format=date-time
 	SinceTime *metav1.Time `json:"sinceTime,omitempty"`
 }
 

--- a/api/v1alpha1/mustgather_types.go
+++ b/api/v1alpha1/mustgather_types.go
@@ -72,7 +72,7 @@ type MustGatherSpec struct {
 // GatherSpec allows specifying the execution details for a must-gather run and the collection behavior.
 // +kubebuilder:validation:XValidation:rule="!(has(self.since) && has(self.sinceTime))",message="only one of since or sinceTime may be specified"
 // +kubebuilder:validation:XValidation:rule="!has(self.since) || !self.since.startsWith(\"-\")",message="since must be a non-negative duration string"
-// +kubebuilder:validation:XValidation:rule="!has(self.since) || self.since.startsWith(\"-\") || self.since.matches(r'^\\+?(([0-9]+(\\.[0-9]*)?|\\.[0-9]+)(ns|µs|us|ms|s|m|h))+$')",message="since may only use these duration suffixes: ns, us, µs, ms, s, m, h (e.g. 2h, 30m, 168h for one week)."
+// +kubebuilder:validation:XValidation:rule="!has(self.since) || self.since.matches(r'^\\+?(([0-9]+(\\.[0-9]*)?|\\.[0-9]+)(ns|µs|us|ms|s|m|h))+$')",message="since may only use these duration suffixes: ns, us, µs, ms, s, m, h (e.g. 2h, 30m, 168h for one week)."
 // +kubebuilder:validation:XValidation:rule="!has(self.sinceTime) || self.sinceTime.matches(r'^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?(Z|[+-]\\d{2}:\\d{2})$')",message="sinceTime must be in RFC3339 format."
 type GatherSpec struct {
 	// +kubebuilder:validation:Optional

--- a/api/v1alpha1/mustgather_types.go
+++ b/api/v1alpha1/mustgather_types.go
@@ -101,8 +101,7 @@ type GatherSpec struct {
 	Since *metav1.Duration `json:"since,omitempty"`
 
 	// SinceTime only returns logs after a specific instant. Use RFC3339 with uppercase T and Z or a zone offset
-	// (e.g. 2026-02-02T00:00:00Z). Must not be after the current time when the operator reconciles the MustGather
-	// (CRD CEL cannot access metadata.creationTimestamp or a wall clock; validation is done in the controller).
+	// (e.g. 2026-02-02T00:00:00Z). Must not be after the current time.
 	// This is passed to the must-gather script to filter log collection.
 	// Only one of since or sinceTime may be specified.
 	// +kubebuilder:validation:Optional

--- a/bundle/manifests/tech-preview/operator.openshift.io_mustgathers.yaml
+++ b/bundle/manifests/tech-preview/operator.openshift.io_mustgathers.yaml
@@ -77,8 +77,7 @@ spec:
                   sinceTime:
                     description: |-
                       SinceTime only returns logs after a specific instant. Use RFC3339 with uppercase T and Z or a zone offset
-                      (e.g. 2026-02-02T00:00:00Z). Must not be after the current time when the operator reconciles the MustGather
-                      (CRD CEL cannot access metadata.creationTimestamp or a wall clock; validation is done in the controller).
+                      (e.g. 2026-02-02T00:00:00Z). Must not be after the current time.
                       This is passed to the must-gather script to filter log collection.
                       Only one of since or sinceTime may be specified.
                     format: date-time

--- a/bundle/manifests/tech-preview/operator.openshift.io_mustgathers.yaml
+++ b/bundle/manifests/tech-preview/operator.openshift.io_mustgathers.yaml
@@ -68,14 +68,17 @@ spec:
                     type: array
                   since:
                     description: |-
-                      Since only returns logs newer than a relative duration like "2h" or "30m".
+                      Since only returns logs newer than a relative duration (e.g. 2h, 30m, 168h for one week). Must be non-negative.
+                      Allowed units are ns, us, µs, ms, s, m, and h.
                       This is passed to the must-gather script to filter log collection.
                       Only one of since or sinceTime may be specified.
                     format: duration
                     type: string
                   sinceTime:
                     description: |-
-                      SinceTime only returns logs after a specific date/time (RFC3339 format).
+                      SinceTime only returns logs after a specific instant. Use RFC3339 with uppercase T and Z or a zone offset
+                      (e.g. 2026-02-02T00:00:00Z). Must not be after the current time when the operator reconciles the MustGather
+                      (CRD CEL cannot access metadata.creationTimestamp or a wall clock; validation is done in the controller).
                       This is passed to the must-gather script to filter log collection.
                       Only one of since or sinceTime may be specified.
                     format: date-time
@@ -84,6 +87,12 @@ spec:
                 x-kubernetes-validations:
                 - message: only one of since or sinceTime may be specified
                   rule: '!(has(self.since) && has(self.sinceTime))'
+                - message: since must be a non-negative duration string
+                  rule: '!has(self.since) || !self.since.startsWith("-")'
+                - message: 'since may only use these duration suffixes: ns, us, µs, ms, s, m, h (e.g. 2h, 30m, 168h for one week).'
+                  rule: "!has(self.since) || self.since.startsWith(\"-\") || self.since.matches(r'^\\+?(([0-9]+(\\.[0-9]*)?|\\.[0-9]+)(ns|µs|us|ms|s|m|h))+$')"
+                - message: sinceTime must be in RFC3339 format.
+                  rule: "!has(self.sinceTime) || self.sinceTime.matches(r'^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?(Z|[+-]\\d{2}:\\d{2})$')"
               imageStreamRef:
                 description: |-
                   ImageStreamRef specifies a custom image from the allowlist to be used for the

--- a/bundle/manifests/tech-preview/operator.openshift.io_mustgathers.yaml
+++ b/bundle/manifests/tech-preview/operator.openshift.io_mustgathers.yaml
@@ -89,8 +89,9 @@ spec:
                   rule: '!(has(self.since) && has(self.sinceTime))'
                 - message: since must be a non-negative duration string
                   rule: '!has(self.since) || !self.since.startsWith("-")'
-                - message: 'since may only use these duration suffixes: ns, us, µs, ms, s, m, h (e.g. 2h, 30m, 168h for one week).'
-                  rule: "!has(self.since) || self.since.startsWith(\"-\") || self.since.matches(r'^\\+?(([0-9]+(\\.[0-9]*)?|\\.[0-9]+)(ns|µs|us|ms|s|m|h))+$')"
+                - message: 'since may only use these duration suffixes: ns, us, µs,
+                    ms, s, m, h (e.g. 2h, 30m, 168h for one week).'
+                  rule: '!has(self.since) || self.since.matches(r''^\+?(([0-9]+(\.[0-9]*)?|\.[0-9]+)(ns|µs|us|ms|s|m|h))+$'')'
                 - message: sinceTime must be in RFC3339 format.
                   rule: "!has(self.sinceTime) || self.sinceTime.matches(r'^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?(Z|[+-]\\d{2}:\\d{2})$')"
               imageStreamRef:

--- a/bundle/manifests/tech-preview/operator.openshift.io_mustgathers.yaml
+++ b/bundle/manifests/tech-preview/operator.openshift.io_mustgathers.yaml
@@ -72,7 +72,6 @@ spec:
                       Allowed units are ns, us, µs, ms, s, m, and h.
                       This is passed to the must-gather script to filter log collection.
                       Only one of since or sinceTime may be specified.
-                    format: duration
                     type: string
                   sinceTime:
                     description: |-

--- a/controllers/mustgather/constant.go
+++ b/controllers/mustgather/constant.go
@@ -20,6 +20,9 @@ const (
 	// ValidationImageStream represents the validation type for ImageStream
 	ValidationImageStream = "ImageStream"
 
+	// ValidationSinceTime represents validation of gatherSpec.sinceTime (e.g. must not be in the future)
+	ValidationSinceTime = "sinceTime"
+
 	// DefaultMustGatherImageEnv represents the environment variable for the default must-gather image
 	DefaultMustGatherImageEnv = "DEFAULT_MUST_GATHER_IMAGE"
 

--- a/controllers/mustgather/mustgather_controller.go
+++ b/controllers/mustgather/mustgather_controller.go
@@ -51,10 +51,6 @@ const (
 
 var log = logf.Log.WithName(ControllerName)
 
-// errValidationFailureHandled is returned when setValidationFailureStatus succeeded so Reconcile
-// must not call ManageError (which would replace status conditions and confuse validation output).
-var errValidationFailureHandled = goerror.New("mustgather: validation failure recorded in status")
-
 // blank assignment to verify that MustGatherReconciler implements reconcile.Reconciler
 var _ reconcile.Reconciler = &MustGatherReconciler{}
 
@@ -161,9 +157,6 @@ func (r *MustGatherReconciler) Reconcile(ctx context.Context, request reconcile.
 
 	job, err := r.getJobFromInstance(ctx, instance)
 	if err != nil {
-		if goerror.Is(err, errValidationFailureHandled) {
-			return reconcile.Result{}, nil
-		}
 		log.Error(err, "unable to get job from", "instance", instance)
 		return r.ManageError(ctx, instance, err)
 	}
@@ -394,7 +387,7 @@ func (r *MustGatherReconciler) getJobFromInstance(ctx context.Context, instance 
 		if validationErr != nil {
 			return nil, fmt.Errorf("failed to set validation failure status for original error %v: %w", err, validationErr)
 		}
-		return nil, fmt.Errorf("%w: %v", errValidationFailureHandled, err)
+		return nil, err
 	}
 
 	// Inject the operator image URI from the pod's env variables
@@ -410,7 +403,7 @@ func (r *MustGatherReconciler) getJobFromInstance(ctx context.Context, instance 
 		if _, validationErr := r.setValidationFailureStatus(ctx, log, instance, ValidationSinceTime, err); validationErr != nil {
 			return nil, fmt.Errorf("failed to set validation failure status: %w, %w", err, validationErr)
 		}
-		return nil, fmt.Errorf("%w: %v", errValidationFailureHandled, err)
+		return nil, err
 	}
 
 	return getJobTemplate(image, operatorImage, *instance, r.TrustedCAConfigMap), nil

--- a/controllers/mustgather/mustgather_controller.go
+++ b/controllers/mustgather/mustgather_controller.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"slices"
+	"time"
 
 	"github.com/go-logr/logr"
 	imagev1 "github.com/openshift/api/image/v1"
@@ -49,6 +50,10 @@ const (
 )
 
 var log = logf.Log.WithName(ControllerName)
+
+// errValidationFailureHandled is returned when setValidationFailureStatus succeeded so Reconcile
+// must not call ManageError (which would replace status conditions and confuse validation output).
+var errValidationFailureHandled = goerror.New("mustgather: validation failure recorded in status")
 
 // blank assignment to verify that MustGatherReconciler implements reconcile.Reconciler
 var _ reconcile.Reconciler = &MustGatherReconciler{}
@@ -156,6 +161,9 @@ func (r *MustGatherReconciler) Reconcile(ctx context.Context, request reconcile.
 
 	job, err := r.getJobFromInstance(ctx, instance)
 	if err != nil {
+		if goerror.Is(err, errValidationFailureHandled) {
+			return reconcile.Result{}, nil
+		}
 		log.Error(err, "unable to get job from", "instance", instance)
 		return r.ManageError(ctx, instance, err)
 	}
@@ -386,7 +394,7 @@ func (r *MustGatherReconciler) getJobFromInstance(ctx context.Context, instance 
 		if validationErr != nil {
 			return nil, fmt.Errorf("failed to set validation failure status for original error %v: %w", err, validationErr)
 		}
-		return nil, err
+		return nil, fmt.Errorf("%w: %v", errValidationFailureHandled, err)
 	}
 
 	// Inject the operator image URI from the pod's env variables
@@ -395,6 +403,14 @@ func (r *MustGatherReconciler) getJobFromInstance(ctx context.Context, instance 
 		err := goerror.New("operator image environment variable not found")
 		log.Error(err, "Error: no operator image found for job template")
 		return nil, err
+	}
+
+	if instance.Spec.GatherSpec != nil && instance.Spec.GatherSpec.SinceTime != nil && instance.Spec.GatherSpec.SinceTime.After(time.Now()) {
+		err := fmt.Errorf("gatherSpec.sinceTime must be at or before the current date and time")
+		if _, validationErr := r.setValidationFailureStatus(ctx, log, instance, ValidationSinceTime, err); validationErr != nil {
+			return nil, fmt.Errorf("failed to set validation failure status: %w, %w", err, validationErr)
+		}
+		return nil, fmt.Errorf("%w: %v", errValidationFailureHandled, err)
 	}
 
 	return getJobTemplate(image, operatorImage, *instance, r.TrustedCAConfigMap), nil

--- a/controllers/mustgather/mustgather_controller_test.go
+++ b/controllers/mustgather/mustgather_controller_test.go
@@ -1588,6 +1588,51 @@ func generateFakeClient(objs ...runtime.Object) (client.Client, *runtime.Scheme)
 	return cl, s
 }
 
+func TestGetJobFromInstanceFutureSinceTimeSetsValidationStatus(t *testing.T) {
+	st := metav1.NewTime(time.Now().Add(48 * time.Hour))
+	mg := &mustgatherv1alpha1.MustGather{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "mg-future-sincetime",
+			Namespace:  "openshift-must-gather-operator",
+			Finalizers: []string{mustGatherFinalizer},
+		},
+		Spec: mustgatherv1alpha1.MustGatherSpec{
+			GatherSpec: &mustgatherv1alpha1.GatherSpec{
+				SinceTime: &st,
+			},
+		},
+	}
+	t.Setenv("OPERATOR_IMAGE", "test-image")
+	t.Setenv("DEFAULT_MUST_GATHER_IMAGE", "test-must-gather-image")
+	cl, s := generateFakeClient(mg)
+	eventRec := record.NewFakeRecorder(10)
+	var cfg *rest.Config
+	r := MustGatherReconciler{
+		ReconcilerBase:         util.NewReconcilerBase(cl, s, cfg, eventRec, nil),
+		DefaultMustGatherImage: "test-must-gather-image",
+		OperatorNamespace:      "openshift-must-gather-operator",
+	}
+
+	_, err := r.getJobFromInstance(context.Background(), mg)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, errValidationFailureHandled) {
+		t.Fatalf("expected errValidationFailureHandled, got %v", err)
+	}
+
+	updated := &mustgatherv1alpha1.MustGather{}
+	if err := cl.Get(context.Background(), types.NamespacedName{Name: mg.Name, Namespace: mg.Namespace}, updated); err != nil {
+		t.Fatal(err)
+	}
+	if updated.Status.Status != "Failed" {
+		t.Fatalf("expected status Failed, got %q", updated.Status.Status)
+	}
+	if !strings.Contains(updated.Status.Reason, ValidationSinceTime) {
+		t.Fatalf("expected reason to mention sinceTime, got %q", updated.Status.Reason)
+	}
+}
+
 // TestSFTPCredentialValidation tests the credential validation logic added in the controller
 func TestSFTPCredentialValidation(t *testing.T) {
 	// Setup scheme

--- a/controllers/mustgather/mustgather_controller_test.go
+++ b/controllers/mustgather/mustgather_controller_test.go
@@ -1617,9 +1617,6 @@ func TestGetJobFromInstanceFutureSinceTimeSetsValidationStatus(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	if !errors.Is(err, errValidationFailureHandled) {
-		t.Fatalf("expected errValidationFailureHandled, got %v", err)
-	}
 
 	updated := &mustgatherv1alpha1.MustGather{}
 	if err := cl.Get(context.Background(), types.NamespacedName{Name: mg.Name, Namespace: mg.Namespace}, updated); err != nil {

--- a/deploy/crds/operator.openshift.io_mustgathers.yaml
+++ b/deploy/crds/operator.openshift.io_mustgathers.yaml
@@ -68,14 +68,16 @@ spec:
                     type: array
                   since:
                     description: |-
-                      Since only returns logs newer than a relative duration like "2h" or "30m".
+                      Since only returns logs newer than a relative duration (e.g. 2h, 30m, 168h for one week). Must be non-negative.
+                      Allowed units are ns, us, µs, ms, s, m, and h.
                       This is passed to the must-gather script to filter log collection.
                       Only one of since or sinceTime may be specified.
-                    format: duration
                     type: string
                   sinceTime:
                     description: |-
-                      SinceTime only returns logs after a specific date/time (RFC3339 format).
+                      SinceTime only returns logs after a specific instant. Use RFC3339 with uppercase T and Z or a zone offset
+                      (e.g. 2026-02-02T00:00:00Z). Must not be after the current time when the operator reconciles the MustGather
+                      (CRD CEL cannot access metadata.creationTimestamp or a wall clock; validation is done in the controller).
                       This is passed to the must-gather script to filter log collection.
                       Only one of since or sinceTime may be specified.
                     format: date-time
@@ -84,6 +86,13 @@ spec:
                 x-kubernetes-validations:
                 - message: only one of since or sinceTime may be specified
                   rule: '!(has(self.since) && has(self.sinceTime))'
+                - message: since must be a non-negative duration string
+                  rule: '!has(self.since) || !self.since.startsWith("-")'
+                - message: 'since may only use these duration suffixes: ns, us, µs,
+                    ms, s, m, h (e.g. 2h, 30m, 168h for one week).'
+                  rule: '!has(self.since) || self.since.startsWith("-") || self.since.matches(r''^\+?(([0-9]+(\.[0-9]*)?|\.[0-9]+)(ns|µs|us|ms|s|m|h))+$'')'
+                - message: sinceTime must be in RFC3339 format.
+                  rule: '!has(self.sinceTime) || self.sinceTime.matches(r''^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})$'')'
               imageStreamRef:
                 description: |-
                   ImageStreamRef specifies a custom image from the allowlist to be used for the

--- a/deploy/crds/operator.openshift.io_mustgathers.yaml
+++ b/deploy/crds/operator.openshift.io_mustgathers.yaml
@@ -90,7 +90,7 @@ spec:
                   rule: '!has(self.since) || !self.since.startsWith("-")'
                 - message: 'since may only use these duration suffixes: ns, us, µs,
                     ms, s, m, h (e.g. 2h, 30m, 168h for one week).'
-                  rule: '!has(self.since) || self.since.startsWith("-") || self.since.matches(r''^\+?(([0-9]+(\.[0-9]*)?|\.[0-9]+)(ns|µs|us|ms|s|m|h))+$'')'
+                  rule: '!has(self.since) || self.since.matches(r''^\+?(([0-9]+(\.[0-9]*)?|\.[0-9]+)(ns|µs|us|ms|s|m|h))+$'')'
                 - message: sinceTime must be in RFC3339 format.
                   rule: '!has(self.sinceTime) || self.sinceTime.matches(r''^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})$'')'
               imageStreamRef:

--- a/deploy/crds/operator.openshift.io_mustgathers.yaml
+++ b/deploy/crds/operator.openshift.io_mustgathers.yaml
@@ -70,15 +70,12 @@ spec:
                     description: |-
                       Since only returns logs newer than a relative duration (e.g. 2h, 30m, 168h for one week). Must be non-negative.
                       Allowed units are ns, us, µs, ms, s, m, and h.
-                      This is passed to the must-gather script to filter log collection.
                       Only one of since or sinceTime may be specified.
                     type: string
                   sinceTime:
                     description: |-
                       SinceTime only returns logs after a specific instant. Use RFC3339 with uppercase T and Z or a zone offset
-                      (e.g. 2026-02-02T00:00:00Z). Must not be after the current time when the operator reconciles the MustGather
-                      (CRD CEL cannot access metadata.creationTimestamp or a wall clock; validation is done in the controller).
-                      This is passed to the must-gather script to filter log collection.
+                      (e.g. 2026-02-02T00:00:00Z). Must not be after the current time.                      
                       Only one of since or sinceTime may be specified.
                     format: date-time
                     type: string


### PR DESCRIPTION
[OCPBUGS-79069](https://redhat.atlassian.net/browse/OCPBUGS-79069) - Fixed the since and sinceTime validation issue.

since: 1d / since: 1w / since: 1y - The invalid values like this give validation error now.
since: -10s / since: -10d - These negative since values give validation error now.
sinceTime: 2026-04-02T00:00:00Z - The future date won't work. The CR error status will be updated now.
sinceTime: 2026-02-02t00:00:00Z / sinceTime: 2026-02-02T00:00:00z - The invalid values like these gives the validation error now.
Validation error for invalid since value - The MustGather "mustgather-with-since" is invalid: spec.gatherSpec: Invalid value: "object": since may only use these duration suffixes: ns, us, µs, ms, s, m, h (e.g. 2h, 30m, 168h for one week).

Validation error for invalid sinceTime value - The MustGather "mustgather-with-sincetime" is invalid: spec.gatherSpec: Invalid value: "object": sinceTime must be in RFC3339 format.

NOTE: since: 0s is not handled as part of this PR.

[OCPBUGS-79069]: https://redhat.atlassian.net/browse/OCPBUGS-79069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter validation for MustGather time filters: `since` must be non-negative and use allowed duration units; `sinceTime` must match RFC3339 and cannot be in the future. Reconciliation now marks instances as validation failures when `sinceTime` is a future timestamp.

* **Tests**
  * Added a unit test covering the future `sinceTime` validation path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->