### PR TITLE
MG-265: Mandate ServiceAccount for MustGather CR for all users

### DIFF
--- a/api/v1alpha1/mustgather_types.go
+++ b/api/v1alpha1/mustgather_types.go
@@ -27,8 +27,6 @@ import (
 // MustGatherSpec defines the desired state of MustGather
 // +kubebuilder:validation:XValidation:rule="!(has(self.gatherSpec) && ((has(self.gatherSpec.command) && size(self.gatherSpec.command) > 0) || (has(self.gatherSpec.args) && size(self.gatherSpec.args) > 0))) || has(self.imageStreamRef)",message="command and args in gatherSpec can only be set when imageStreamRef is specified"
 // +kubebuilder:validation:XValidation:rule="!(has(self.gatherSpec) && self.gatherSpec.audit == true && (has(self.imageStreamRef) || (has(self.gatherSpec.command) && size(self.gatherSpec.command) > 0)))",message="audit cannot be used with a custom image (imageStreamRef) or custom command"
-// +kubebuilder:validation:XValidation:rule="!(has(self.imageStreamRef) && has(self.gatherSpec) && has(self.gatherSpec.audit) && self.gatherSpec.audit)",message="audit cannot be enabled when using a custom image (imageStreamRef)"
-// +kubebuilder:validation:XValidation:rule="!(!has(self.imageStreamRef) && has(self.gatherSpec) && has(self.gatherSpec.command) && size(self.gatherSpec.command) > 0 && has(self.gatherSpec.audit) && self.gatherSpec.audit)",message="audit cannot be enabled when gatherSpec.command is set with the default must-gather image"
 type MustGatherSpec struct {
 	// The service account to use to run the must-gather job pod.
 	// Users must explicitly specify a ServiceAccount with sufficient permissions.

--- a/api/v1alpha1/mustgather_types.go
+++ b/api/v1alpha1/mustgather_types.go
@@ -26,11 +26,14 @@ import (
 
 // MustGatherSpec defines the desired state of MustGather
 // +kubebuilder:validation:XValidation:rule="!(has(self.gatherSpec) && ((has(self.gatherSpec.command) && size(self.gatherSpec.command) > 0) || (has(self.gatherSpec.args) && size(self.gatherSpec.args) > 0))) || has(self.imageStreamRef)",message="command and args in gatherSpec can only be set when imageStreamRef is specified"
+// +kubebuilder:validation:XValidation:rule="!(has(self.imageStreamRef) && has(self.gatherSpec) && self.gatherSpec.audit == true)",message="audit cannot be used with a custom image (imageStreamRef)"
+// +kubebuilder:validation:XValidation:rule="!(has(self.gatherSpec) && self.gatherSpec.audit == true && has(self.gatherSpec.command) && size(self.gatherSpec.command) > 0 && !has(self.imageStreamRef))",message="audit cannot be used when gatherSpec.command is set without imageStreamRef"
 type MustGatherSpec struct {
-	// the service account to use to run the must gather job pod, defaults to default
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:default:="default"
-	ServiceAccountName string `json:"serviceAccountName,omitempty"`
+	// The service account to use to run the must-gather job pod.
+	// Users must explicitly specify a ServiceAccount with sufficient permissions.
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinLength=1
+	ServiceAccountName string `json:"serviceAccountName"`
 
 	// ImageStreamRef specifies a custom image from the allowlist to be used for the
 	// must-gather run.

--- a/api/v1alpha1/mustgather_types.go
+++ b/api/v1alpha1/mustgather_types.go
@@ -26,8 +26,7 @@ import (
 
 // MustGatherSpec defines the desired state of MustGather
 // +kubebuilder:validation:XValidation:rule="!(has(self.gatherSpec) && ((has(self.gatherSpec.command) && size(self.gatherSpec.command) > 0) || (has(self.gatherSpec.args) && size(self.gatherSpec.args) > 0))) || has(self.imageStreamRef)",message="command and args in gatherSpec can only be set when imageStreamRef is specified"
-// +kubebuilder:validation:XValidation:rule="!(has(self.imageStreamRef) && has(self.gatherSpec) && self.gatherSpec.audit == true)",message="audit cannot be used with a custom image (imageStreamRef)"
-// +kubebuilder:validation:XValidation:rule="!(has(self.gatherSpec) && self.gatherSpec.audit == true && has(self.gatherSpec.command) && size(self.gatherSpec.command) > 0 && !has(self.imageStreamRef))",message="audit cannot be used when gatherSpec.command is set without imageStreamRef"
+// +kubebuilder:validation:XValidation:rule="!(has(self.gatherSpec) && self.gatherSpec.audit == true && (has(self.imageStreamRef) || (has(self.gatherSpec.command) && size(self.gatherSpec.command) > 0)))",message="audit cannot be used with a custom image (imageStreamRef) or custom command"
 // +kubebuilder:validation:XValidation:rule="!(has(self.imageStreamRef) && has(self.gatherSpec) && has(self.gatherSpec.audit) && self.gatherSpec.audit)",message="audit cannot be enabled when using a custom image (imageStreamRef)"
 // +kubebuilder:validation:XValidation:rule="!(!has(self.imageStreamRef) && has(self.gatherSpec) && has(self.gatherSpec.command) && size(self.gatherSpec.command) > 0 && has(self.gatherSpec.audit) && self.gatherSpec.audit)",message="audit cannot be enabled when gatherSpec.command is set with the default must-gather image"
 type MustGatherSpec struct {

--- a/api/v1alpha1/mustgather_types.go
+++ b/api/v1alpha1/mustgather_types.go
@@ -26,7 +26,7 @@ import (
 
 // MustGatherSpec defines the desired state of MustGather
 // +kubebuilder:validation:XValidation:rule="!(has(self.gatherSpec) && ((has(self.gatherSpec.command) && size(self.gatherSpec.command) > 0) || (has(self.gatherSpec.args) && size(self.gatherSpec.args) > 0))) || has(self.imageStreamRef)",message="command and args in gatherSpec can only be set when imageStreamRef is specified"
-// +kubebuilder:validation:XValidation:rule="!(has(self.gatherSpec) && self.gatherSpec.audit == true && (has(self.imageStreamRef) || (has(self.gatherSpec.command) && size(self.gatherSpec.command) > 0)))",message="audit cannot be used with a custom image (imageStreamRef) or custom command"
+// +kubebuilder:validation:XValidation:rule="!(has(self.gatherSpec) && has(self.gatherSpec.audit) && self.gatherSpec.audit == true && (has(self.imageStreamRef) || (has(self.gatherSpec.command) && size(self.gatherSpec.command) > 0)))",message="audit cannot be used with a custom image (imageStreamRef) or custom command"
 type MustGatherSpec struct {
 	// The service account to use to run the must-gather job pod.
 	// Users must explicitly specify a ServiceAccount with sufficient permissions.

--- a/bundle/manifests/tech-preview/operator.openshift.io_mustgathers.yaml
+++ b/bundle/manifests/tech-preview/operator.openshift.io_mustgathers.yaml
@@ -238,17 +238,9 @@ spec:
                 0))) || has(self.imageStreamRef)'
             - message: audit cannot be used with a custom image (imageStreamRef) or
                 custom command
-              rule: '!(has(self.gatherSpec) && self.gatherSpec.audit == true && (has(self.imageStreamRef)
-                || (has(self.gatherSpec.command) && size(self.gatherSpec.command)
-                > 0)))'
-            - message: audit cannot be enabled when using a custom image (imageStreamRef)
-              rule: '!(has(self.imageStreamRef) && has(self.gatherSpec) && has(self.gatherSpec.audit)
-                && self.gatherSpec.audit)'
-            - message: audit cannot be enabled when gatherSpec.command is set with
-                the default must-gather image
-              rule: '!(!has(self.imageStreamRef) && has(self.gatherSpec) && has(self.gatherSpec.command)
-                && size(self.gatherSpec.command) > 0 && has(self.gatherSpec.audit)
-                && self.gatherSpec.audit)'
+              rule: '!(has(self.gatherSpec) && has(self.gatherSpec.audit) && self.gatherSpec.audit
+                == true && (has(self.imageStreamRef) || (has(self.gatherSpec.command)
+                && size(self.gatherSpec.command) > 0)))'
           status:
             description: MustGatherStatus defines the observed state of MustGather
             properties:

--- a/bundle/manifests/tech-preview/operator.openshift.io_mustgathers.yaml
+++ b/bundle/manifests/tech-preview/operator.openshift.io_mustgathers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.16.4
   name: mustgathers.operator.openshift.io
 spec:
   group: operator.openshift.io
@@ -116,9 +116,10 @@ spec:
                   If set to true, resources will be retained. If false or not set, resources will be deleted (default behavior).
                 type: boolean
               serviceAccountName:
-                default: default
-                description: the service account to use to run the must gather job
-                  pod, defaults to default
+                description: |-
+                  The service account to use to run the must-gather job pod.
+                  Users must explicitly specify a ServiceAccount with sufficient permissions.
+                minLength: 1
                 type: string
               storage:
                 description: |-
@@ -228,6 +229,8 @@ spec:
                     is SFTP, and forbidden otherwise
                   rule: 'has(self.type) && self.type == ''SFTP'' ? has(self.sftp)
                     : !has(self.sftp)'
+            required:
+            - serviceAccountName
             type: object
             x-kubernetes-validations:
             - message: command and args in gatherSpec can only be set when imageStreamRef
@@ -235,6 +238,13 @@ spec:
               rule: '!(has(self.gatherSpec) && ((has(self.gatherSpec.command) && size(self.gatherSpec.command)
                 > 0) || (has(self.gatherSpec.args) && size(self.gatherSpec.args) >
                 0))) || has(self.imageStreamRef)'
+            - message: audit cannot be used with a custom image (imageStreamRef)
+              rule: '!(has(self.imageStreamRef) && has(self.gatherSpec) && self.gatherSpec.audit
+                == true)'
+            - message: audit cannot be used when gatherSpec.command is set without
+                imageStreamRef
+              rule: '!(has(self.gatherSpec) && self.gatherSpec.audit == true && has(self.gatherSpec.command)
+                && size(self.gatherSpec.command) > 0 && !has(self.imageStreamRef))'
           status:
             description: MustGatherStatus defines the observed state of MustGather
             properties:

--- a/bundle/manifests/tech-preview/operator.openshift.io_mustgathers.yaml
+++ b/bundle/manifests/tech-preview/operator.openshift.io_mustgathers.yaml
@@ -236,13 +236,11 @@ spec:
               rule: '!(has(self.gatherSpec) && ((has(self.gatherSpec.command) && size(self.gatherSpec.command)
                 > 0) || (has(self.gatherSpec.args) && size(self.gatherSpec.args) >
                 0))) || has(self.imageStreamRef)'
-            - message: audit cannot be used with a custom image (imageStreamRef)
-              rule: '!(has(self.imageStreamRef) && has(self.gatherSpec) && self.gatherSpec.audit
-                == true)'
-            - message: audit cannot be used when gatherSpec.command is set without
-                imageStreamRef
-              rule: '!(has(self.gatherSpec) && self.gatherSpec.audit == true && has(self.gatherSpec.command)
-                && size(self.gatherSpec.command) > 0 && !has(self.imageStreamRef))'
+            - message: audit cannot be used with a custom image (imageStreamRef) or
+                custom command
+              rule: '!(has(self.gatherSpec) && self.gatherSpec.audit == true && (has(self.imageStreamRef)
+                || (has(self.gatherSpec.command) && size(self.gatherSpec.command)
+                > 0)))'
             - message: audit cannot be enabled when using a custom image (imageStreamRef)
               rule: '!(has(self.imageStreamRef) && has(self.gatherSpec) && has(self.gatherSpec.audit)
                 && self.gatherSpec.audit)'

--- a/controllers/mustgather/mustgather_controller.go
+++ b/controllers/mustgather/mustgather_controller.go
@@ -178,25 +178,18 @@ func (r *MustGatherReconciler) Reconcile(ctx context.Context, request reconcile.
 
 		// Validate that the ServiceAccount exists before creating the Job.
 		// This prevents the Job from being stuck in pending state due to a missing ServiceAccount.
-		// If no ServiceAccount is specified, default to "default" which should exist in all namespaces.
-		// Note: If the "default" SA has been deleted, this validation will catch it and report an error.
-		saName := instance.Spec.ServiceAccountName
-		if saName == "" {
-			saName = "default"
-			log.Info("no serviceAccountName specified, defaulting to 'default'", "namespace", instance.Namespace)
-		}
 		serviceAccount := &corev1.ServiceAccount{}
 		err = r.GetClient().Get(ctx, types.NamespacedName{
 			Namespace: instance.Namespace,
-			Name:      saName,
+			Name:      instance.Spec.ServiceAccountName,
 		}, serviceAccount)
 		if err != nil {
 			if errors.IsNotFound(err) {
-				log.Error(err, "service account not found", "name", saName, "namespace", instance.Namespace)
+				log.Error(err, "service account not found", "name", instance.Spec.ServiceAccountName, "namespace", instance.Namespace)
 				return r.setValidationFailureStatus(ctx, reqLogger, instance, ValidationServiceAccount, err)
 			}
 
-			log.Error(err, "failed to get service account (transient error, will retry)", "name", saName, "namespace", instance.Namespace)
+			log.Error(err, "failed to get service account (transient error, will retry)", "name", instance.Spec.ServiceAccountName, "namespace", instance.Namespace)
 			return reconcile.Result{Requeue: true}, err
 		}
 

--- a/controllers/mustgather/mustgather_controller_test.go
+++ b/controllers/mustgather/mustgather_controller_test.go
@@ -109,6 +109,7 @@ func TestCleanupMustGatherResources(t *testing.T) {
 				mg := &mustgatherv1alpha1.MustGather{
 					ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: targetNamespace},
 					Spec: mustgatherv1alpha1.MustGatherSpec{
+						ServiceAccountName: "default",
 						UploadTarget: &mustgatherv1alpha1.UploadTargetSpec{
 							Type: mustgatherv1alpha1.UploadTypeSFTP,
 							SFTP: &mustgatherv1alpha1.SFTPSpec{
@@ -138,7 +139,7 @@ func TestCleanupMustGatherResources(t *testing.T) {
 			setupObjects: func() []client.Object {
 				mg := &mustgatherv1alpha1.MustGather{
 					ObjectMeta: metav1.ObjectMeta{Name: "mg", Namespace: targetNamespace},
-					Spec:       mustgatherv1alpha1.MustGatherSpec{},
+					Spec:       mustgatherv1alpha1.MustGatherSpec{ServiceAccountName: "default"},
 				}
 				sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: targetNamespace}}
 				return []client.Object{mg, sa}
@@ -161,7 +162,7 @@ func TestCleanupMustGatherResources(t *testing.T) {
 			setupObjects: func() []client.Object {
 				mg := &mustgatherv1alpha1.MustGather{
 					ObjectMeta: metav1.ObjectMeta{Name: "mg", Namespace: targetNamespace},
-					Spec:       mustgatherv1alpha1.MustGatherSpec{},
+					Spec:       mustgatherv1alpha1.MustGatherSpec{ServiceAccountName: "default"},
 				}
 				job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: mg.Name, Namespace: targetNamespace, UID: "u"}}
 				return []client.Object{mg, job}
@@ -190,7 +191,7 @@ func TestCleanupMustGatherResources(t *testing.T) {
 			setupObjects: func() []client.Object {
 				mg := &mustgatherv1alpha1.MustGather{
 					ObjectMeta: metav1.ObjectMeta{Name: "mg", Namespace: targetNamespace},
-					Spec:       mustgatherv1alpha1.MustGatherSpec{},
+					Spec:       mustgatherv1alpha1.MustGatherSpec{ServiceAccountName: "default"},
 				}
 				job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: mg.Name, Namespace: targetNamespace, UID: "u"}}
 				pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p1", Namespace: targetNamespace, Labels: map[string]string{"controller-uid": string(job.UID)}}}
@@ -283,7 +284,7 @@ func TestHandleJobCompletion(t *testing.T) {
 			setupObjects: func() []client.Object {
 				mg := &mustgatherv1alpha1.MustGather{
 					ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: operatorNs},
-					Spec:       mustgatherv1alpha1.MustGatherSpec{},
+					Spec:       mustgatherv1alpha1.MustGatherSpec{ServiceAccountName: "default"},
 				}
 				job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: mg.Name, Namespace: operatorNs, UID: "uid-1"}}
 				pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: operatorNs, Labels: map[string]string{"controller-uid": string(job.UID)}}}
@@ -312,7 +313,7 @@ func TestHandleJobCompletion(t *testing.T) {
 			setupObjects: func() []client.Object {
 				mg := &mustgatherv1alpha1.MustGather{
 					ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: operatorNs},
-					Spec:       mustgatherv1alpha1.MustGatherSpec{},
+					Spec:       mustgatherv1alpha1.MustGatherSpec{ServiceAccountName: "default"},
 				}
 				job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: mg.Name, Namespace: operatorNs, UID: "uid-2"}}
 				return []client.Object{mg, job}
@@ -341,6 +342,7 @@ func TestHandleJobCompletion(t *testing.T) {
 				mg := &mustgatherv1alpha1.MustGather{
 					ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: operatorNs},
 					Spec: mustgatherv1alpha1.MustGatherSpec{
+						ServiceAccountName:          "default",
 						RetainResourcesOnCompletion: ToPtr(true),
 					},
 				}
@@ -371,6 +373,7 @@ func TestHandleJobCompletion(t *testing.T) {
 				mg := &mustgatherv1alpha1.MustGather{
 					ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: operatorNs},
 					Spec: mustgatherv1alpha1.MustGatherSpec{
+						ServiceAccountName:          "default",
 						RetainResourcesOnCompletion: ToPtr(true),
 					},
 				}
@@ -400,7 +403,7 @@ func TestHandleJobCompletion(t *testing.T) {
 			setupObjects: func() []client.Object {
 				mg := &mustgatherv1alpha1.MustGather{
 					ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: operatorNs},
-					Spec:       mustgatherv1alpha1.MustGatherSpec{},
+					Spec:       mustgatherv1alpha1.MustGatherSpec{ServiceAccountName: "default"},
 				}
 				return []client.Object{mg}
 			},
@@ -419,7 +422,7 @@ func TestHandleJobCompletion(t *testing.T) {
 			setupObjects: func() []client.Object {
 				mg := &mustgatherv1alpha1.MustGather{
 					ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: operatorNs},
-					Spec:       mustgatherv1alpha1.MustGatherSpec{},
+					Spec:       mustgatherv1alpha1.MustGatherSpec{ServiceAccountName: "default"},
 				}
 				job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: mg.Name, Namespace: operatorNs, UID: "uid-5"}}
 				return []client.Object{mg, job}
@@ -527,7 +530,7 @@ func TestReconcile(t *testing.T) {
 		{
 			name: "reconcile_initialize_mustgather_update_succeeds",
 			setupObjects: func() []client.Object {
-				mg := &mustgatherv1alpha1.MustGather{ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: "ns"}}
+				mg := &mustgatherv1alpha1.MustGather{ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: "ns"}, Spec: mustgatherv1alpha1.MustGatherSpec{ServiceAccountName: "default"}}
 				sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: "ns"}}
 				return []client.Object{mg, sa}
 			},
@@ -539,7 +542,7 @@ func TestReconcile(t *testing.T) {
 		{
 			name: "reconcile_initialize_mustgather_update_fails",
 			setupObjects: func() []client.Object {
-				mg := &mustgatherv1alpha1.MustGather{ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: "ns"}}
+				mg := &mustgatherv1alpha1.MustGather{ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: "ns"}, Spec: mustgatherv1alpha1.MustGatherSpec{ServiceAccountName: "default"}}
 				sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: "ns"}}
 				return []client.Object{mg, sa}
 			},
@@ -728,92 +731,6 @@ func TestReconcile(t *testing.T) {
 				expectedReason := "Service Account validation failed"
 				if !strings.Contains(out.Status.Reason, expectedReason) {
 					t.Fatalf("expected reason to contain %q, got %q", expectedReason, out.Status.Reason)
-				}
-			},
-		},
-		{
-			name: "reconcile_empty_service_account_name_defaults_to_default",
-			setupEnv: func(t *testing.T) {
-				t.Setenv("OPERATOR_IMAGE", "img")
-			},
-			setupObjects: func() []client.Object {
-				mg := &mustgatherv1alpha1.MustGather{
-					ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: "ns", Finalizers: []string{mustGatherFinalizer}},
-					Spec: mustgatherv1alpha1.MustGatherSpec{
-						// ServiceAccountName is empty, should validate "default" SA exists
-						ServiceAccountName: "",
-					},
-				}
-				// Create "default" service account that should be validated
-				sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: "ns"}}
-				cv := &configv1.ClusterVersion{
-					ObjectMeta: metav1.ObjectMeta{Name: "version"},
-					Status: configv1.ClusterVersionStatus{
-						History: []configv1.UpdateHistory{{State: "Completed", Version: "1.2.3"}},
-					},
-				}
-				return []client.Object{mg, sa, cv}
-			},
-			interceptors: func() interceptClient { return interceptClient{} },
-			expectError:  false,
-			expectResult: reconcile.Result{},
-			postTestChecks: func(t *testing.T, cl client.Client) {
-				// Verify the Job was created successfully, proving the validation passed
-				// When ServiceAccountName is empty, the controller validates "default" SA exists
-				job := &batchv1.Job{}
-				if err := cl.Get(context.TODO(), types.NamespacedName{Namespace: "ns", Name: "example-mustgather"}, job); err != nil {
-					t.Fatalf("expected job to be created when 'default' service account exists: %v", err)
-				}
-				// The job's ServiceAccountName will match the MustGather spec (empty string)
-				// Kubernetes will implicitly use "default" when the field is empty
-				if job.Spec.Template.Spec.ServiceAccountName != "" {
-					t.Fatalf("expected job ServiceAccountName to be empty (matching spec), got: %q", job.Spec.Template.Spec.ServiceAccountName)
-				}
-			},
-		},
-		{
-			name: "reconcile_empty_service_account_name_default_not_found_calls_manage_error",
-			setupEnv: func(t *testing.T) {
-				t.Setenv("OPERATOR_IMAGE", "img")
-			},
-			setupObjects: func() []client.Object {
-				mg := &mustgatherv1alpha1.MustGather{
-					ObjectMeta: metav1.ObjectMeta{Name: "example-mustgather", Namespace: "ns", Finalizers: []string{mustGatherFinalizer}},
-					Spec: mustgatherv1alpha1.MustGatherSpec{
-						// ServiceAccountName is empty, should try to validate "default" SA
-						ServiceAccountName: "",
-					},
-				}
-				cv := &configv1.ClusterVersion{
-					ObjectMeta: metav1.ObjectMeta{Name: "version"},
-					Status: configv1.ClusterVersionStatus{
-						History: []configv1.UpdateHistory{{State: "Completed", Version: "1.2.3"}},
-					},
-				}
-				// Note: Not creating "default" SA to simulate it being deleted
-				return []client.Object{mg, cv}
-			},
-			interceptors: func() interceptClient { return interceptClient{} },
-			expectError:  false,
-			expectResult: reconcile.Result{},
-			postTestChecks: func(t *testing.T, cl client.Client) {
-				// Verify the MustGather status was updated with error condition
-				out := &mustgatherv1alpha1.MustGather{}
-				if getErr := cl.Get(context.TODO(), types.NamespacedName{Name: "example-mustgather", Namespace: "ns"}, out); getErr != nil {
-					t.Fatalf("failed to get mustgather: %v", getErr)
-				}
-				// setValidationFailureStatus sets Status to Failed
-				if out.Status.Status != "Failed" {
-					t.Fatalf("expected status to be Failed, got %s", out.Status.Status)
-				}
-				expectedReason := "Service Account validation failed"
-				if !strings.Contains(out.Status.Reason, expectedReason) {
-					t.Fatalf("expected reason to contain %q, got %q", expectedReason, out.Status.Reason)
-				}
-				// Verify Job was not created
-				job := &batchv1.Job{}
-				if err := cl.Get(context.TODO(), types.NamespacedName{Namespace: "ns", Name: "example-mustgather"}, job); err == nil {
-					t.Fatalf("expected job to not be created when 'default' service account is missing")
 				}
 			},
 		},
@@ -1529,7 +1446,9 @@ func createMustGatherObject() *mustgatherv1alpha1.MustGather {
 			Name:      "example-mustgather",
 			Namespace: "openshift-must-gather-operator",
 		},
-		Spec: mustgatherv1alpha1.MustGatherSpec{},
+		Spec: mustgatherv1alpha1.MustGatherSpec{
+			ServiceAccountName: "default",
+		},
 	}
 }
 
@@ -1628,6 +1547,7 @@ func TestSFTPCredentialValidation(t *testing.T) {
 					Finalizers: []string{mustGatherFinalizer},
 				},
 				Spec: mustgatherv1alpha1.MustGatherSpec{
+					ServiceAccountName: "default",
 					UploadTarget: &mustgatherv1alpha1.UploadTargetSpec{
 						Type: mustgatherv1alpha1.UploadTypeSFTP,
 						SFTP: &mustgatherv1alpha1.SFTPSpec{
@@ -1667,6 +1587,7 @@ func TestSFTPCredentialValidation(t *testing.T) {
 					Finalizers: []string{mustGatherFinalizer},
 				},
 				Spec: mustgatherv1alpha1.MustGatherSpec{
+					ServiceAccountName: "default",
 					UploadTarget: &mustgatherv1alpha1.UploadTargetSpec{
 						Type: mustgatherv1alpha1.UploadTypeSFTP,
 						SFTP: &mustgatherv1alpha1.SFTPSpec{
@@ -1705,6 +1626,7 @@ func TestSFTPCredentialValidation(t *testing.T) {
 					Finalizers: []string{mustGatherFinalizer},
 				},
 				Spec: mustgatherv1alpha1.MustGatherSpec{
+					ServiceAccountName: "default",
 					UploadTarget: &mustgatherv1alpha1.UploadTargetSpec{
 						Type: mustgatherv1alpha1.UploadTypeSFTP,
 						SFTP: &mustgatherv1alpha1.SFTPSpec{
@@ -1744,6 +1666,7 @@ func TestSFTPCredentialValidation(t *testing.T) {
 					Finalizers: []string{mustGatherFinalizer},
 				},
 				Spec: mustgatherv1alpha1.MustGatherSpec{
+					ServiceAccountName: "default",
 					UploadTarget: &mustgatherv1alpha1.UploadTargetSpec{
 						Type: mustgatherv1alpha1.UploadTypeSFTP,
 						SFTP: &mustgatherv1alpha1.SFTPSpec{
@@ -1783,6 +1706,7 @@ func TestSFTPCredentialValidation(t *testing.T) {
 					Finalizers: []string{mustGatherFinalizer},
 				},
 				Spec: mustgatherv1alpha1.MustGatherSpec{
+					ServiceAccountName: "default",
 					UploadTarget: &mustgatherv1alpha1.UploadTargetSpec{
 						Type: mustgatherv1alpha1.UploadTypeSFTP,
 						SFTP: &mustgatherv1alpha1.SFTPSpec{
@@ -1824,6 +1748,7 @@ func TestSFTPCredentialValidation(t *testing.T) {
 					Finalizers: []string{mustGatherFinalizer},
 				},
 				Spec: mustgatherv1alpha1.MustGatherSpec{
+					ServiceAccountName: "default",
 					UploadTarget: &mustgatherv1alpha1.UploadTargetSpec{
 						Type: mustgatherv1alpha1.UploadTypeSFTP,
 						SFTP: &mustgatherv1alpha1.SFTPSpec{
@@ -1867,6 +1792,7 @@ func TestSFTPCredentialValidation(t *testing.T) {
 					Finalizers: []string{mustGatherFinalizer},
 				},
 				Spec: mustgatherv1alpha1.MustGatherSpec{
+					ServiceAccountName: "default",
 					UploadTarget: &mustgatherv1alpha1.UploadTargetSpec{
 						Type: mustgatherv1alpha1.UploadTypeSFTP,
 						SFTP: &mustgatherv1alpha1.SFTPSpec{

--- a/deploy/crds/operator.openshift.io_mustgathers.yaml
+++ b/deploy/crds/operator.openshift.io_mustgathers.yaml
@@ -238,17 +238,9 @@ spec:
                 0))) || has(self.imageStreamRef)'
             - message: audit cannot be used with a custom image (imageStreamRef) or
                 custom command
-              rule: '!(has(self.gatherSpec) && self.gatherSpec.audit == true && (has(self.imageStreamRef)
-                || (has(self.gatherSpec.command) && size(self.gatherSpec.command)
-                > 0)))'
-            - message: audit cannot be enabled when using a custom image (imageStreamRef)
-              rule: '!(has(self.imageStreamRef) && has(self.gatherSpec) && has(self.gatherSpec.audit)
-                && self.gatherSpec.audit)'
-            - message: audit cannot be enabled when gatherSpec.command is set with
-                the default must-gather image
-              rule: '!(!has(self.imageStreamRef) && has(self.gatherSpec) && has(self.gatherSpec.command)
-                && size(self.gatherSpec.command) > 0 && has(self.gatherSpec.audit)
-                && self.gatherSpec.audit)'
+              rule: '!(has(self.gatherSpec) && has(self.gatherSpec.audit) && self.gatherSpec.audit
+                == true && (has(self.imageStreamRef) || (has(self.gatherSpec.command)
+                && size(self.gatherSpec.command) > 0)))'
           status:
             description: MustGatherStatus defines the observed state of MustGather
             properties:

--- a/deploy/crds/operator.openshift.io_mustgathers.yaml
+++ b/deploy/crds/operator.openshift.io_mustgathers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.16.4
   name: mustgathers.operator.openshift.io
 spec:
   group: operator.openshift.io
@@ -116,9 +116,10 @@ spec:
                   If set to true, resources will be retained. If false or not set, resources will be deleted (default behavior).
                 type: boolean
               serviceAccountName:
-                default: default
-                description: the service account to use to run the must gather job
-                  pod, defaults to default
+                description: |-
+                  The service account to use to run the must-gather job pod.
+                  Users must explicitly specify a ServiceAccount with sufficient permissions.
+                minLength: 1
                 type: string
               storage:
                 description: |-
@@ -228,6 +229,8 @@ spec:
                     is SFTP, and forbidden otherwise
                   rule: 'has(self.type) && self.type == ''SFTP'' ? has(self.sftp)
                     : !has(self.sftp)'
+            required:
+            - serviceAccountName
             type: object
             x-kubernetes-validations:
             - message: command and args in gatherSpec can only be set when imageStreamRef
@@ -235,6 +238,13 @@ spec:
               rule: '!(has(self.gatherSpec) && ((has(self.gatherSpec.command) && size(self.gatherSpec.command)
                 > 0) || (has(self.gatherSpec.args) && size(self.gatherSpec.args) >
                 0))) || has(self.imageStreamRef)'
+            - message: audit cannot be used with a custom image (imageStreamRef)
+              rule: '!(has(self.imageStreamRef) && has(self.gatherSpec) && self.gatherSpec.audit
+                == true)'
+            - message: audit cannot be used when gatherSpec.command is set without
+                imageStreamRef
+              rule: '!(has(self.gatherSpec) && self.gatherSpec.audit == true && has(self.gatherSpec.command)
+                && size(self.gatherSpec.command) > 0 && !has(self.imageStreamRef))'
           status:
             description: MustGatherStatus defines the observed state of MustGather
             properties:

--- a/deploy/crds/operator.openshift.io_mustgathers.yaml
+++ b/deploy/crds/operator.openshift.io_mustgathers.yaml
@@ -236,13 +236,11 @@ spec:
               rule: '!(has(self.gatherSpec) && ((has(self.gatherSpec.command) && size(self.gatherSpec.command)
                 > 0) || (has(self.gatherSpec.args) && size(self.gatherSpec.args) >
                 0))) || has(self.imageStreamRef)'
-            - message: audit cannot be used with a custom image (imageStreamRef)
-              rule: '!(has(self.imageStreamRef) && has(self.gatherSpec) && self.gatherSpec.audit
-                == true)'
-            - message: audit cannot be used when gatherSpec.command is set without
-                imageStreamRef
-              rule: '!(has(self.gatherSpec) && self.gatherSpec.audit == true && has(self.gatherSpec.command)
-                && size(self.gatherSpec.command) > 0 && !has(self.imageStreamRef))'
+            - message: audit cannot be used with a custom image (imageStreamRef) or
+                custom command
+              rule: '!(has(self.gatherSpec) && self.gatherSpec.audit == true && (has(self.imageStreamRef)
+                || (has(self.gatherSpec.command) && size(self.gatherSpec.command)
+                > 0)))'
             - message: audit cannot be enabled when using a custom image (imageStreamRef)
               rule: '!(has(self.imageStreamRef) && has(self.gatherSpec) && has(self.gatherSpec.audit)
                 && self.gatherSpec.audit)'

--- a/test/e2e/must_gather_operator_test.go
+++ b/test/e2e/must_gather_operator_test.go
@@ -27,7 +27,9 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -850,16 +852,18 @@ var _ = ginkgo.Describe("MustGather resource", ginkgo.Ordered, func() {
 		ginkgo.It("should reject MustGather CR without serviceAccountName", func() {
 			mustGatherName := fmt.Sprintf("test-no-sa-%d", time.Now().UnixNano())
 
-			ginkgo.By("Creating MustGather CR without serviceAccountName")
-			mg = &mustgatherv1alpha1.MustGather{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      mustGatherName,
-					Namespace: ns.Name,
-				},
-				Spec: mustgatherv1alpha1.MustGatherSpec{},
-			}
+			ginkgo.By("Creating unstructured MustGather CR with spec that omits serviceAccountName entirely")
+			obj := &unstructured.Unstructured{}
+			obj.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   mustgatherv1alpha1.GroupVersion.Group,
+				Version: mustgatherv1alpha1.GroupVersion.Version,
+				Kind:    "MustGather",
+			})
+			obj.SetName(mustGatherName)
+			obj.SetNamespace(ns.Name)
+			obj.Object["spec"] = map[string]interface{}{}
 
-			err := nonAdminClient.Create(testCtx, mg)
+			err := nonAdminClient.Create(testCtx, obj)
 			Expect(err).To(HaveOccurred(), "CR without serviceAccountName should be rejected at admission")
 			Expect(apierrors.IsInvalid(err)).To(BeTrue(),
 				"Error should be a validation error for missing required field")

--- a/test/e2e/must_gather_operator_test.go
+++ b/test/e2e/must_gather_operator_test.go
@@ -867,6 +867,29 @@ var _ = ginkgo.Describe("MustGather resource", ginkgo.Ordered, func() {
 			ginkgo.GinkgoWriter.Printf("CR correctly rejected at admission: %v\n", err)
 			mg = nil
 		})
+
+		ginkgo.It("should reject MustGather CR with empty serviceAccountName", func() {
+			mustGatherName := fmt.Sprintf("test-empty-sa-%d", time.Now().UnixNano())
+
+			ginkgo.By("Creating MustGather CR with explicit empty serviceAccountName")
+			mg = &mustgatherv1alpha1.MustGather{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      mustGatherName,
+					Namespace: ns.Name,
+				},
+				Spec: mustgatherv1alpha1.MustGatherSpec{
+					ServiceAccountName: "",
+				},
+			}
+
+			err := nonAdminClient.Create(testCtx, mg)
+			Expect(err).To(HaveOccurred(), "CR with empty serviceAccountName should be rejected at admission")
+			Expect(apierrors.IsInvalid(err)).To(BeTrue(),
+				"Error should be a validation error for MinLength=1 violation")
+
+			ginkgo.GinkgoWriter.Printf("CR with empty serviceAccountName correctly rejected at admission: %v\n", err)
+			mg = nil
+		})
 	})
 
 	ginkgo.Context("UploadTarget SFTP Configuration Tests", func() {

--- a/test/e2e/must_gather_operator_test.go
+++ b/test/e2e/must_gather_operator_test.go
@@ -846,6 +846,27 @@ var _ = ginkgo.Describe("MustGather resource", ginkgo.Ordered, func() {
 			Expect(err).To(HaveOccurred(), "Non-admin should NOT be able to modify ServiceAccounts")
 			Expect(apierrors.IsForbidden(err)).To(BeTrue(), "Should get Forbidden error")
 		})
+
+		ginkgo.It("should reject MustGather CR without serviceAccountName", func() {
+			mustGatherName := fmt.Sprintf("test-no-sa-%d", time.Now().UnixNano())
+
+			ginkgo.By("Creating MustGather CR without serviceAccountName")
+			mg = &mustgatherv1alpha1.MustGather{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      mustGatherName,
+					Namespace: ns.Name,
+				},
+				Spec: mustgatherv1alpha1.MustGatherSpec{},
+			}
+
+			err := nonAdminClient.Create(testCtx, mg)
+			Expect(err).To(HaveOccurred(), "CR without serviceAccountName should be rejected at admission")
+			Expect(apierrors.IsInvalid(err)).To(BeTrue(),
+				"Error should be a validation error for missing required field")
+
+			ginkgo.GinkgoWriter.Printf("CR correctly rejected at admission: %v\n", err)
+			mg = nil
+		})
 	})
 
 	ginkgo.Context("UploadTarget SFTP Configuration Tests", func() {


### PR DESCRIPTION
## Summary

- Make `serviceAccountName` a required field on the MustGather CR with `minLength: 1`, removing the default value of `"default"`.
- Remove controller fallback logic that silently defaulted to the `"default"` ServiceAccount when the field was empty.
- Add two new CEL validation rules for the `audit` field (rejected with custom image, rejected with custom command without imageStreamRef). The original command/args CEL rule is intentionally retained as it serves a different purpose.

## Why

Previously, the operator silently fell back to the default ServiceAccount, which often lacks the permissions needed for must-gather jobs, causing jobs to hang or fail in confusing ways. Making the field required forces users to be intentional about which SA they use, eliminating ambiguity for both admin and non-admin users.

## Changes

| Area | Change |
|------|--------|
| `api/v1alpha1/mustgather_types.go` | Replaced `+kubebuilder:validation:Optional` and `+kubebuilder:default:="default"` with `+kubebuilder:validation:Required` and `+kubebuilder:validation:MinLength=1`. Removed `omitempty` from JSON tag. Added two new CEL rules for audit field validation (retained existing command/args rule). |
| `controllers/mustgather/mustgather_controller.go` | Removed the `if saName == ""` fallback block. Controller now uses `instance.Spec.ServiceAccountName` directly since it's guaranteed non-empty at admission. |
| `controllers/mustgather/mustgather_controller_test.go` | Removed two tests for empty SA defaulting. Updated all test objects to explicitly set `ServiceAccountName`. |
| `test/e2e/must_gather_operator_test.go` | Added negative E2E test verifying that a CR without `serviceAccountName` is rejected at admission. |
| `deploy/crds/` and `bundle/manifests/` | Regenerated CRD manifests reflecting the new required field, minLength, and CEL rules. |

## Test plan

- [x] All existing unit tests pass with updated SA field
- [x] `go vet ./...` passes
- [x] `go build ./...` compiles cleanly
- [x] E2E test added: CR without `serviceAccountName` is rejected at admission
- [ ] E2E tests verify existing behavior is unaffected when a valid SA is provided

🤖 Generated with [Claude Code](https://claude.com/claude-code) via `/jira:solve [MG-265](https://redhat.atlassian.net/browse/MG-265)`

[MG-265]: https://redhat.atlassian.net/browse/MG-265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * spec.serviceAccountName is now required (non-empty) and no longer defaults to "default".
  * New validations: gatherSpec.command/args may only be set with a custom image; gatherSpec.audit: true is forbidden when using a custom image or a custom command without a custom image.
* **Bug Fixes**
  * Pre-flight service-account validation now uses the provided serviceAccountName (no implicit default).
* **Tests**
  * Added e2e tests ensuring creation without a valid spec.serviceAccountName is rejected; unit tests updated to include serviceAccountName.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->