### PR TITLE
feat: add SFTP port field and fix gather job RBAC

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ spec:
 
 This request will collect the standard must-gather info and upload it to case `#02527285` using the credentials found in the `caseManagementCreds` secret.
 
+> **Note:** `serviceAccountName: default` is valid for limited-privilege collections. For full must-gather collection and cluster-scoped RBAC operations (including node-level data), use `serviceAccountName: must-gather-admin`. See [Using the must-gather-admin service account](#using-the-must-gather-admin-service-account) for details.
+
 ## Using a custom SFTP port
 
 By default the operator uploads to `sftp.access.redhat.com` on port 22. If outbound port 22 is blocked in your environment, Red Hat also accepts uploads on port 80 at the same address. Set the optional `port` field to override:
@@ -99,7 +101,7 @@ The operator's service account (`must-gather-operator`) requires cluster-level *
 
 If you see the following error in operator logs:
 
-```
+```text
 serviceaccounts is forbidden: User "system:serviceaccount:must-gather-operator:must-gather-operator" cannot list resource "serviceaccounts" in API group ""
 ```
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ kind: MustGather
 metadata:
   name: example-mustgather-basic
 spec:
-  serviceAccountName: must-gather-admin
+  serviceAccountName: default
   uploadTarget:
     type: SFTP
     sftp:
@@ -20,6 +20,28 @@ spec:
 
 This request will collect the standard must-gather info and upload it to case `#02527285` using the credentials found in the `caseManagementCreds` secret.
 
+## Using a custom SFTP port
+
+By default the operator uploads to `sftp.access.redhat.com` on port 22. If outbound port 22 is blocked in your environment, Red Hat also accepts uploads on port 80 at the same address. Set the optional `port` field to override:
+
+```yaml
+apiVersion: operator.openshift.io/v1alpha1
+kind: MustGather
+metadata:
+  name: example-mustgather-port80
+spec:
+  serviceAccountName: default
+  uploadTarget:
+    type: SFTP
+    sftp:
+      caseID: '02527285'
+      caseManagementAccountSecretRef:
+        name: case-management-creds
+      port: 80
+```
+
+`port` accepts any value from 1–65535 and defaults to 22 when omitted.
+
 ## Collecting Audit logs
 The field `audit` is **false** by default unless explicetely set to **true**.
 This will generate the default collection of audit logs as per [the collection script: gather_audit_logs](https://github.com/openshift/must-gather/blob/master/collection-scripts/gather_audit_logs)
@@ -29,7 +51,7 @@ kind: MustGather
 metadata:
   name: example-mustgather-full
 spec:
-  serviceAccountName: must-gather-admin
+  serviceAccountName: default
   uploadTarget:
     type: SFTP
     sftp:
@@ -59,6 +81,10 @@ oc new-project must-gather-operator
 oc -n must-gather-operator apply -f deploy
 ```
 
+> **Note:** The `deploy/` manifests include two sets of RBAC resources:
+> - `04_must-gather-admin.ServiceAccount.yaml`, `05_must-gather-admin.ClusterRole.yaml`, and `06_must-gather-admin.ClusterRoleBinding.yaml` create the `must-gather-admin` ServiceAccount with cluster-admin equivalent access plus the `privileged` SCC. Use `serviceAccountName: must-gather-admin` in your MustGather CR for the gather job.
+> - `07_must-gather-operator-default-sa.ClusterRoleBinding.privileged.yaml` grants the `default` ServiceAccount in `must-gather-operator` the same permissions. This is required because the `perf-node-gather-daemonset` (created dynamically by the must-gather image) runs under the `default` SA and needs `hostPID`, `hostPath` volumes, and cluster-level API access. Without this binding, daemonset pods will fail to schedule and node-level performance data will be missing from the bundle.
+
 ### Meeting the operator requirements
 
 In order to run, the operator needs a secret to be created by the admin as follows (this assumes the operator is running in the `must-gather-operator` namespace).
@@ -66,6 +92,34 @@ In order to run, the operator needs a secret to be created by the admin as follo
 ```shell
 oc create secret generic case-management-creds --from-literal=username=<username> --from-literal=password=<password>
 ```
+
+#### Required RBAC permissions
+
+The operator's service account (`must-gather-operator`) requires cluster-level **get/list/watch** on `serviceaccounts` to validate that the service account referenced in the MustGather CR exists before creating the gather job. When deploying via OLM this rule must be present in the CSV's `clusterPermissions` section. When deploying with manifests it is included in `deploy/02_must-gather-operator.ClusterRole.yaml`.
+
+If you see the following error in operator logs:
+
+```
+serviceaccounts is forbidden: User "system:serviceaccount:must-gather-operator:must-gather-operator" cannot list resource "serviceaccounts" in API group ""
+```
+
+Apply the missing rule manually:
+
+```shell
+oc patch clusterrole <must-gather-operator-clusterrole-name> --type=json \
+  -p='[{"op":"add","path":"/rules/-","value":{"apiGroups":[""],"resources":["serviceaccounts"],"verbs":["get","list","watch"]}}]'
+```
+
+#### Using the must-gather-admin service account
+
+The `must-gather-admin` ServiceAccount (created by `deploy/04_must-gather-admin.ServiceAccount.yaml`) has the permissions required to run the full must-gather collection. Set `serviceAccountName: must-gather-admin` in your MustGather CR:
+
+```yaml
+spec:
+  serviceAccountName: must-gather-admin
+```
+
+The `perf-node-gather-daemonset` created by the must-gather image always runs under the `default` ServiceAccount in the operator namespace. The `deploy/07_must-gather-operator-default-sa.ClusterRoleBinding.privileged.yaml` manifest grants the `default` SA the same permissions so that daemonset pods can use `hostPID` and `hostPath` volumes and access cluster APIs.
 
 ## Local Development
 

--- a/api/v1alpha1/mustgather_types.go
+++ b/api/v1alpha1/mustgather_types.go
@@ -138,6 +138,13 @@ type SFTPSpec struct {
 	// +kubebuilder:default:="sftp.access.redhat.com"
 	// +optional
 	Host string `json:"host,omitempty"`
+
+	// port specifies the SFTP server port.
+	// +kubebuilder:default:=22
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=65535
+	// +optional
+	Port int `json:"port,omitempty"`
 }
 
 // UploadType defines the type of upload target.

--- a/build/bin/upload
+++ b/build/bin/upload
@@ -17,8 +17,9 @@ CURRENT_TIMESTAMP=$(date --utc +%Y%m%d_%H%M%SZ)
 CSP_FILENAME=${FILENAME_PREFIX}-${CURRENT_TIMESTAMP}.tar.gz
 CSP_FILE="${must_gather_upload}/${CSP_FILENAME}"
 FTP_HOST=${host:-"sftp.access.redhat.com"}
+FTP_PORT=${port:-"22"}
 KNOWN_HOSTS_PATH="/tmp/must-gather-operator/.ssh/known_hosts"
-SFTP_OPTIONS="-o BatchMode=no -o StrictHostKeyChecking=no -o UserKnownHostsFile=${KNOWN_HOSTS_PATH} "
+SFTP_OPTIONS="-o BatchMode=no -o StrictHostKeyChecking=no -o UserKnownHostsFile=${KNOWN_HOSTS_PATH} -o Port=${FTP_PORT} "
 
 # Setup proxy command if proxy environment variables are set
 PROXY_COMMAND=""

--- a/bundle/manifests/tech-preview/operator.openshift.io_mustgathers.yaml
+++ b/bundle/manifests/tech-preview/operator.openshift.io_mustgathers.yaml
@@ -203,6 +203,12 @@ spec:
                           A flag to specify if the upload user provided in the caseManagementAccountSecret is a RH internal user.
                           See documentation for further information.
                         type: boolean
+                      port:
+                        default: 22
+                        description: port specifies the SFTP server port.
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
                     required:
                     - caseID
                     - caseManagementAccountSecretRef

--- a/controllers/mustgather/mustgather_controller.go
+++ b/controllers/mustgather/mustgather_controller.go
@@ -241,6 +241,7 @@ func (r *MustGatherReconciler) Reconcile(ctx context.Context, request reconcile.
 				string(username),
 				string(password),
 				instance.Spec.UploadTarget.SFTP.Host,
+				instance.Spec.UploadTarget.SFTP.Port,
 			)
 			if validationErr != nil {
 				reqLogger.Error(validationErr, "SFTP credential validation failed")

--- a/controllers/mustgather/mustgather_controller_test.go
+++ b/controllers/mustgather/mustgather_controller_test.go
@@ -1360,7 +1360,7 @@ func TestReconcile(t *testing.T) {
 			defer func() { sftpDialFunc = originalSftpDialFunc }()
 
 			// Mock SFTP dial function to always succeed
-			sftpDialFunc = func(ctx context.Context, username, password, host string) error {
+			sftpDialFunc = func(ctx context.Context, username, password, host string, port int) error {
 				return nil // Mock success - allows validation to pass and test job creation logic
 			}
 
@@ -1600,7 +1600,7 @@ func TestSFTPCredentialValidation(t *testing.T) {
 		name                     string
 		secret                   *corev1.Secret
 		mustgather               *mustgatherv1alpha1.MustGather
-		mockSFTPDialFunc         func(ctx context.Context, username, password, host string) error
+		mockSFTPDialFunc         func(ctx context.Context, username, password, host string, port int) error
 		expectError              bool
 		expectedStatus           string
 		expectedCompleted        bool
@@ -1793,7 +1793,7 @@ func TestSFTPCredentialValidation(t *testing.T) {
 					},
 				},
 			},
-			mockSFTPDialFunc: func(ctx context.Context, username, password, host string) error {
+			mockSFTPDialFunc: func(ctx context.Context, username, password, host string, port int) error {
 				return errors.New("SFTP connection failed: authentication failed")
 			},
 			expectError:              false,
@@ -1834,7 +1834,7 @@ func TestSFTPCredentialValidation(t *testing.T) {
 					},
 				},
 			},
-			mockSFTPDialFunc: func(ctx context.Context, username, password, host string) error {
+			mockSFTPDialFunc: func(ctx context.Context, username, password, host string, port int) error {
 				// Use context.DeadlineExceeded to simulate a transient error
 				// Local retry will exhaust all attempts and then fail
 				return context.DeadlineExceeded
@@ -1877,7 +1877,7 @@ func TestSFTPCredentialValidation(t *testing.T) {
 					},
 				},
 			},
-			mockSFTPDialFunc: func(ctx context.Context, username, password, host string) error {
+			mockSFTPDialFunc: func(ctx context.Context, username, password, host string, port int) error {
 				return nil // Success
 			},
 			expectError: false,
@@ -1909,7 +1909,7 @@ func TestSFTPCredentialValidation(t *testing.T) {
 				sftpDialFunc = tt.mockSFTPDialFunc
 			} else {
 				// Safety: fail if the dial is called unexpectedly
-				sftpDialFunc = func(ctx context.Context, username, password, host string) error {
+				sftpDialFunc = func(ctx context.Context, username, password, host string, port int) error {
 					t.Fatal("sftpDialFunc called unexpectedly")
 					return nil
 				}

--- a/controllers/mustgather/template.go
+++ b/controllers/mustgather/template.go
@@ -48,6 +48,7 @@ const (
 	uploadEnvNoProxy          = "no_proxy"
 	uploadEnvMustGatherOutput = "must_gather_output"
 	uploadEnvMustGatherUpload = "must_gather_upload"
+	uploadEnvPort             = "port"
 	uploadCommand             = "count=0\nuntil [ $count -gt 4 ]\ndo\n  while `pgrep -a gather > /dev/null`\n  do\n    echo \"waiting for gathers to complete ...\"\n    sleep 120\n    count=0\n  done\n  echo \"no gather is running ($count / 4)\"\n  ((count++))\n  sleep 30\ndone\n/usr/local/bin/upload"
 
 	// SSH directory and known hosts file
@@ -150,6 +151,7 @@ func getJobTemplate(image string, operatorImage string, mustGather v1alpha1.Must
 					s.CaseID,
 					s.Host,
 					s.InternalUser,
+					s.Port,
 					mustGather.Spec.Storage,
 					httpProxy,
 					httpsProxy,
@@ -320,6 +322,7 @@ func getUploadContainer(
 	caseId string,
 	host string,
 	internalUser bool,
+	port int,
 	storage *v1alpha1.Storage,
 	httpProxy string,
 	httpsProxy string,
@@ -354,6 +357,10 @@ func getUploadContainer(
 			MountPath: trustedCAMountPath,
 			ReadOnly:  true,
 		})
+	}
+
+	if port == 0 {
+		port = 22
 	}
 
 	container := corev1.Container{
@@ -403,6 +410,10 @@ func getUploadContainer(
 			{
 				Name:  uploadEnvInternalUser,
 				Value: strconv.FormatBool(internalUser),
+			},
+			{
+				Name:  uploadEnvPort,
+				Value: strconv.Itoa(port),
 			},
 		},
 	}

--- a/controllers/mustgather/template_test.go
+++ b/controllers/mustgather/template_test.go
@@ -325,6 +325,7 @@ func Test_getUploadContainer(t *testing.T) {
 		caseId           string
 		host             string
 		internalUser     bool
+		port             int
 		storage          *mustgatherv1alpha1.Storage
 		httpProxy        string
 		httpsProxy       string
@@ -447,11 +448,27 @@ func Test_getUploadContainer(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:             "Custom port 80",
+			operatorImage:    "testImage",
+			caseId:           "1234",
+			host:             "sftp.example.com",
+			port:             80,
+			secretKeyRefName: v1.LocalObjectReference{Name: "testSecretKeyRefName"},
+		},
+		{
+			name:             "Port defaults to 22 when zero",
+			operatorImage:    "testImage",
+			caseId:           "1234",
+			host:             "sftp.example.com",
+			port:             0,
+			secretKeyRefName: v1.LocalObjectReference{Name: "testSecretKeyRefName"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			testFailed := false
-			container := getUploadContainer(tt.operatorImage, tt.caseId, tt.host, tt.internalUser, tt.storage, tt.httpProxy, tt.httpsProxy, tt.noProxy, tt.secretKeyRefName, tt.mountCAConfigMap)
+			container := getUploadContainer(tt.operatorImage, tt.caseId, tt.host, tt.internalUser, tt.port, tt.storage, tt.httpProxy, tt.httpsProxy, tt.noProxy, tt.secretKeyRefName, tt.mountCAConfigMap)
 
 			if container.Image != tt.operatorImage {
 				t.Fatalf("expected container image %v but got %v", tt.operatorImage, container.Image)
@@ -534,6 +551,14 @@ func Test_getUploadContainer(t *testing.T) {
 				case uploadEnvNoProxy:
 					if env.Value != tt.noProxy {
 						t.Fatalf("expected noproxy envar %v but got %v", tt.noProxy, env.Value)
+					}
+				case uploadEnvPort:
+					expectedPort := tt.port
+					if expectedPort == 0 {
+						expectedPort = 22
+					}
+					if env.Value != strconv.Itoa(expectedPort) {
+						t.Fatalf("expected port envar %d but got %v", expectedPort, env.Value)
 					}
 				case uploadEnvUsername, uploadEnvPassword:
 					if !reflect.DeepEqual(env.ValueFrom.SecretKeyRef.LocalObjectReference, tt.secretKeyRefName) {

--- a/controllers/mustgather/validation.go
+++ b/controllers/mustgather/validation.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strconv"
 	"strings"
 	"time"
 
@@ -24,7 +25,7 @@ const (
 // sftpDialFunc is the function used to test SFTP connections.
 // It can be overridden in tests to avoid real network calls.
 // The context parameter allows for cancellation and timeout control.
-var sftpDialFunc = checkSFTPConnection
+var sftpDialFunc func(ctx context.Context, username, password, host string, port int) error = checkSFTPConnection
 
 // netDialFunc is the function used to dial TCP connections with context support.
 // It can be overridden in tests to avoid real network calls.
@@ -132,18 +133,19 @@ func validateSFTPCredentials(
 	username string,
 	password string,
 	host string,
+	port int,
 ) error {
 	// Call dial function with context for cancellation support
-	return sftpDialFunc(ctx, username, password, host)
+	return sftpDialFunc(ctx, username, password, host, port)
 }
 
 // validateSFTPWithRetry attempts SFTP validation with retries for transient errors.
 // It retries up to MaxSFTPValidationRetries times for transient errors (e.g., timeouts).
 // Non-transient errors (e.g., auth failures) are returned immediately without retry.
-func validateSFTPWithRetry(ctx context.Context, reqLogger logr.Logger, username, password, host string) error {
+func validateSFTPWithRetry(ctx context.Context, reqLogger logr.Logger, username, password, host string, port int) error {
 	var lastErr error
 	for attempt := 1; attempt <= MaxSFTPValidationRetries; attempt++ {
-		lastErr = validateSFTPCredentials(ctx, username, password, host)
+		lastErr = validateSFTPCredentials(ctx, username, password, host, port)
 		if lastErr == nil {
 			return nil
 		}
@@ -169,8 +171,8 @@ func validateSFTPWithRetry(ctx context.Context, reqLogger logr.Logger, username,
 //
 // The TCP connection respects context cancellation. The SSH handshake timeout is controlled
 // by sshDialTimeout (5 seconds) in the SSH config.
-func checkSFTPConnection(ctx context.Context, username, password, host string) error {
-	address := normalizeHostAddress(host)
+func checkSFTPConnection(ctx context.Context, username, password, host string, port int) error {
+	address := normalizeHostAddress(host, port)
 
 	// Skip host key verification to match upload script (StrictHostKeyChecking=no)
 	// #nosec G106 -- Intentional: matches upload script behavior
@@ -196,10 +198,15 @@ func checkSFTPConnection(ctx context.Context, username, password, host string) e
 
 // normalizeHostAddress adds the default SFTP port if not specified.
 // It handles both IPv4 and IPv6 addresses, ensuring IPv6 addresses are correctly bracketed.
-func normalizeHostAddress(host string) string {
+func normalizeHostAddress(host string, port int) string {
 	if host == "" || containsPort(host) {
 		return host
 	}
+
+	if port == 0 {
+		port = 22
+	}
+	portStr := strconv.Itoa(port)
 
 	// If the host is already bracketed (IPv6), strip brackets so JoinHostPort can re-add them correctly
 	// along with the port. JoinHostPort automatically brackets IPv6 literals.
@@ -207,7 +214,7 @@ func normalizeHostAddress(host string) string {
 		host = host[1 : len(host)-1]
 	}
 
-	return net.JoinHostPort(host, sftpDefaultPort)
+	return net.JoinHostPort(host, portStr)
 }
 
 // buildSSHConfig creates an SSH client configuration with the provided credentials and host key callback.

--- a/controllers/mustgather/validation_test.go
+++ b/controllers/mustgather/validation_test.go
@@ -98,55 +98,82 @@ func Test_normalizeHostAddress(t *testing.T) {
 	tests := []struct {
 		name     string
 		host     string
+		port     int
 		expected string
 	}{
 		{
 			name:     "empty host",
 			host:     "",
+			port:     0,
 			expected: "",
 		},
 		{
-			name:     "IPv4 without port",
+			name:     "IPv4 without port uses port param",
 			host:     "192.168.1.1",
+			port:     22,
 			expected: "192.168.1.1:22",
 		},
 		{
-			name:     "IPv4 with port",
+			name:     "IPv4 without port uses custom port",
+			host:     "192.168.1.1",
+			port:     80,
+			expected: "192.168.1.1:80",
+		},
+		{
+			name:     "IPv4 without port defaults to 22 when zero",
+			host:     "192.168.1.1",
+			port:     0,
+			expected: "192.168.1.1:22",
+		},
+		{
+			name:     "IPv4 with port kept as-is",
 			host:     "192.168.1.1:2222",
+			port:     22,
 			expected: "192.168.1.1:2222",
 		},
 		{
-			name:     "hostname without port",
+			name:     "hostname without port uses port param",
 			host:     "example.com",
+			port:     22,
 			expected: "example.com:22",
 		},
 		{
-			name:     "hostname with port",
+			name:     "hostname without port uses custom port",
+			host:     "example.com",
+			port:     80,
+			expected: "example.com:80",
+		},
+		{
+			name:     "hostname with port kept as-is",
 			host:     "example.com:2222",
+			port:     22,
 			expected: "example.com:2222",
 		},
 		{
-			name:     "IPv6 unbracketed",
+			name:     "IPv6 unbracketed without port gets bracketed with port",
 			host:     "2001:db8::1",
+			port:     22,
 			expected: "[2001:db8::1]:22",
 		},
 		{
-			name:     "IPv6 bracketed without port",
+			name:     "IPv6 bracketed without port uses param",
 			host:     "[2001:db8::1]",
+			port:     22,
 			expected: "[2001:db8::1]:22",
 		},
 		{
-			name:     "IPv6 bracketed with port",
+			name:     "IPv6 bracketed with port kept as-is",
 			host:     "[2001:db8::1]:2222",
+			port:     22,
 			expected: "[2001:db8::1]:2222",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := normalizeHostAddress(tt.host)
+			got := normalizeHostAddress(tt.host, tt.port)
 			if got != tt.expected {
-				t.Errorf("normalizeHostAddress(%q) = %q, want %q", tt.host, got, tt.expected)
+				t.Errorf("normalizeHostAddress(%q, %d) = %q, want %q", tt.host, tt.port, got, tt.expected)
 			}
 		})
 	}
@@ -367,6 +394,7 @@ func Test_checkSFTPConnection(t *testing.T) {
 		username    string
 		password    string
 		host        string
+		port        int
 		wantErr     bool
 		errContains string
 	}{
@@ -375,6 +403,7 @@ func Test_checkSFTPConnection(t *testing.T) {
 			username:    "user",
 			password:    "pass",
 			host:        "",
+			port:        0,
 			wantErr:     true,
 			errContains: "Connection refused",
 		},
@@ -383,6 +412,7 @@ func Test_checkSFTPConnection(t *testing.T) {
 			username:    "user",
 			password:    "pass",
 			host:        "192.168.1.1",
+			port:        22,
 			wantErr:     true,
 			errContains: "Connection refused",
 		},
@@ -391,6 +421,7 @@ func Test_checkSFTPConnection(t *testing.T) {
 			username:    "user",
 			password:    "pass",
 			host:        "192.168.1.1:22",
+			port:        22,
 			wantErr:     true,
 			errContains: "Connection refused",
 		},
@@ -399,6 +430,7 @@ func Test_checkSFTPConnection(t *testing.T) {
 			username:    "user",
 			password:    "pass",
 			host:        "sftp.example.com",
+			port:        22,
 			wantErr:     true,
 			errContains: "Connection refused",
 		},
@@ -407,6 +439,7 @@ func Test_checkSFTPConnection(t *testing.T) {
 			username:    "user",
 			password:    "pass",
 			host:        "sftp.example.com:2222",
+			port:        22,
 			wantErr:     true,
 			errContains: "Connection refused",
 		},
@@ -415,6 +448,7 @@ func Test_checkSFTPConnection(t *testing.T) {
 			username:    "user",
 			password:    "pass",
 			host:        "2001:db8::1",
+			port:        22,
 			wantErr:     true,
 			errContains: "Connection refused",
 		},
@@ -423,6 +457,7 @@ func Test_checkSFTPConnection(t *testing.T) {
 			username:    "user",
 			password:    "pass",
 			host:        "[2001:db8::1]",
+			port:        22,
 			wantErr:     true,
 			errContains: "Connection refused",
 		},
@@ -431,6 +466,16 @@ func Test_checkSFTPConnection(t *testing.T) {
 			username:    "user",
 			password:    "pass",
 			host:        "[2001:db8::1]:2222",
+			port:        22,
+			wantErr:     true,
+			errContains: "Connection refused",
+		},
+		{
+			name:        "custom port 80",
+			username:    "user",
+			password:    "pass",
+			host:        "sftp.example.com",
+			port:        80,
 			wantErr:     true,
 			errContains: "Connection refused",
 		},
@@ -446,7 +491,7 @@ func Test_checkSFTPConnection(t *testing.T) {
 				return nil, errors.New("connection refused")
 			}
 
-			err := checkSFTPConnection(context.Background(), tt.username, tt.password, tt.host)
+			err := checkSFTPConnection(context.Background(), tt.username, tt.password, tt.host, tt.port)
 
 			if tt.wantErr {
 				if err == nil {
@@ -509,7 +554,7 @@ func Test_checkSFTPConnection_ContextCancellation(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), tt.timeout)
 			defer cancel()
 
-			err := checkSFTPConnection(ctx, tt.username, tt.password, tt.host)
+			err := checkSFTPConnection(ctx, tt.username, tt.password, tt.host, 22)
 
 			if tt.wantErr {
 				if err == nil {
@@ -566,12 +611,12 @@ func Test_validateSFTPCredentials(t *testing.T) {
 			originalDialFunc := sftpDialFunc
 			defer func() { sftpDialFunc = originalDialFunc }()
 
-			sftpDialFunc = func(ctx context.Context, username, password, host string) error {
+			sftpDialFunc = func(ctx context.Context, username, password, host string, port int) error {
 				return tt.mockDialErr
 			}
 
 			// Run the validation
-			err := validateSFTPCredentials(context.Background(), tt.username, tt.password, tt.host)
+			err := validateSFTPCredentials(context.Background(), tt.username, tt.password, tt.host, 22)
 
 			if tt.wantErr {
 				if err == nil {
@@ -597,14 +642,14 @@ func Test_validateSFTPCredentials_Timeout(t *testing.T) {
 	testCtx, testCancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer testCancel()
 
-	sftpDialFunc = func(ctx context.Context, username, password, host string) error {
+	sftpDialFunc = func(ctx context.Context, username, password, host string, port int) error {
 		// Block until the passed context is cancelled (respecting context cancellation)
 		<-ctx.Done()
 		return ctx.Err()
 	}
 
 	// Run the validation (should timeout based on context)
-	err := validateSFTPCredentials(testCtx, "user", "pass", "sftp.example.com")
+	err := validateSFTPCredentials(testCtx, "user", "pass", "sftp.example.com", 22)
 
 	if err == nil {
 		t.Errorf("validateSFTPCredentials() expected timeout error, got nil")
@@ -685,7 +730,7 @@ func Test_validateSFTPWithRetry(t *testing.T) {
 			defer func() { sftpDialFunc = originalDialFunc }()
 
 			callCount := 0
-			sftpDialFunc = func(ctx context.Context, username, password, host string) error {
+			sftpDialFunc = func(ctx context.Context, username, password, host string, port int) error {
 				if callCount < len(tt.mockDialErrors) {
 					err := tt.mockDialErrors[callCount]
 					callCount++
@@ -696,7 +741,7 @@ func Test_validateSFTPWithRetry(t *testing.T) {
 			}
 
 			logger := logr.Discard()
-			err := validateSFTPWithRetry(context.Background(), logger, "user", "pass", "sftp.example.com")
+			err := validateSFTPWithRetry(context.Background(), logger, "user", "pass", "sftp.example.com", 22)
 
 			if tt.wantErr {
 				if err == nil {

--- a/deploy/01_must-gather-operator.ServiceAccount.yaml
+++ b/deploy/01_must-gather-operator.ServiceAccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: must-gather-operator
+  namespace: must-gather-operator

--- a/deploy/04_must-gather-admin.ServiceAccount.yaml
+++ b/deploy/04_must-gather-admin.ServiceAccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: must-gather-admin
+  namespace: must-gather-operator

--- a/deploy/05_must-gather-admin.ClusterRole.yaml
+++ b/deploy/05_must-gather-admin.ClusterRole.yaml
@@ -13,3 +13,11 @@ rules:
   - '*'
   verbs:
   - '*'
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use

--- a/deploy/07_must-gather-operator-default-sa.ClusterRoleBinding.privileged.yaml
+++ b/deploy/07_must-gather-operator-default-sa.ClusterRoleBinding.privileged.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: must-gather-operator-default-privileged
+roleRef:
+  kind: ClusterRole
+  name: must-gather-admin
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: must-gather-operator

--- a/deploy/crds/operator.openshift.io_mustgathers.yaml
+++ b/deploy/crds/operator.openshift.io_mustgathers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: mustgathers.operator.openshift.io
 spec:
   group: operator.openshift.io
@@ -203,6 +203,12 @@ spec:
                           A flag to specify if the upload user provided in the caseManagementAccountSecret is a RH internal user.
                           See documentation for further information.
                         type: boolean
+                      port:
+                        default: 22
+                        description: port specifies the SFTP server port.
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
                     required:
                     - caseID
                     - caseManagementAccountSecretRef


### PR DESCRIPTION
## Summary

- Add optional `port` field to `SFTPSpec` (default: 22, range: 1–65535) so operators can upload to `sftp.access.redhat.com` on port 80 when outbound port 22 is blocked. See [Red Hat KCS article 5594481](https://access.redhat.com/articles/5594481) for background on Red Hat's dual-port SFTP support.
- Thread the port value through the job template (as `port` env var), upload shell script (`-o Port=`), and SFTP validation functions.
- Add `must-gather-admin` ServiceAccount, ClusterRole (cluster-admin equivalent + `privileged` SCC), and ClusterRoleBinding to deploy manifests. Use `serviceAccountName: must-gather-admin` in MustGather CRs for full collection.
- Add `deploy/01_must-gather-operator.ServiceAccount.yaml` so the operator SA exists when deploying without OLM.
- Add `deploy/07` ClusterRoleBinding granting the `default` SA in `must-gather-operator` the `must-gather-admin` ClusterRole. Required because `perf-node-gather-daemonset` is created dynamically by the must-gather image with no `serviceAccountName`, so it runs as `default` and needs `privileged` SCC plus cluster API access to schedule and collect node performance data.

## Test Plan
- [x] Clean-deploy from manifests: `oc apply -f deploy/crds/... && oc new-project must-gather-operator && oc -n must-gather-operator apply -f deploy/`
- [x] Create MustGather CR with `serviceAccountName: must-gather-admin` and `port: 80` — verify upload pod has env var `port=80` and `status=Completed`
- [x] Verify `perf-node-gather-daemonset` 5/5 pods schedule and complete
- [x] Create MustGather CR without `port` field — verify it defaults to 22
- [x] `make go-test` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for custom SFTP upload ports (1–65535, default 22).

* **Documentation**
  * Updated must-gather examples to use the default service account.
  * Added “Using a custom SFTP port” guidance and examples.
  * Expanded operator deployment docs with RBAC, ServiceAccount, and required permission guidance (including privileged binding notes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->