### PR TITLE
Remove srep-infra-cicd from OWNERS files [SDCICD-1761]

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -69,10 +69,6 @@ aliases:
     - xiaoyu74
     - Tessg22
     - smarthall
-  srep-infra-cicd:
-    - ritmun
-    - yiqinzhang
-    - varunraokadaparthi
   srep-functional-leads:
     - abyrne55
     - clcollins

--- a/boilerplate/openshift/golang-osd-e2e/OWNERS
+++ b/boilerplate/openshift/golang-osd-e2e/OWNERS
@@ -1,4 +1,2 @@
 reviewers:
-- srep-infra-cicd
 approvers:
-- srep-infra-cicd

--- a/boilerplate/openshift/golang-osd-operator-osde2e/OWNERS
+++ b/boilerplate/openshift/golang-osd-operator-osde2e/OWNERS
@@ -1,4 +1,2 @@
 reviewers:
-- srep-infra-cicd
 approvers:
-- srep-infra-cicd

--- a/boilerplate/openshift/golang-osd-operator/OWNERS_ALIASES
+++ b/boilerplate/openshift/golang-osd-operator/OWNERS_ALIASES
@@ -69,10 +69,6 @@ aliases:
     - xiaoyu74
     - Tessg22
     - smarthall
-  srep-infra-cicd:
-    - ritmun
-    - yiqinzhang
-    - varunraokadaparthi
   srep-functional-leads:
     - abyrne55
     - clcollins


### PR DESCRIPTION
The srep-infra-cicd migration is now complete. This PR removes the team as owners from this repository.

Related: Similar cleanup across OpenShift managed services repositories.