### PR TITLE
MG-336: Added obfuscation logs to must-gather

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.25-openshift-4.22
+  tag: rhel-9-release-golang-1.26-openshift-5.0

--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 AS builder
 
 # Copy and download the dependecies so that they are cached locally in the stages.
 WORKDIR /go/src/github.com/openshift/must-gather-operator
@@ -7,7 +7,7 @@ COPY . /go/src/github.com/openshift/must-gather-operator
 
 RUN make go-build
 
-FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
+FROM registry.ci.openshift.org/ocp/5.0:base-rhel9
 
 RUN dnf install -y tar gzip openssh-clients wget shadow-utils procps sshpass nc && \
     dnf clean all

--- a/boilerplate/openshift/golang-osd-operator/ensure.sh
+++ b/boilerplate/openshift/golang-osd-operator/ensure.sh
@@ -8,7 +8,7 @@ fi
 REPO_ROOT=$(git rev-parse --show-toplevel)
 source $REPO_ROOT/boilerplate/_lib/common.sh
 
-GOLANGCI_LINT_VERSION="2.7.2"
+GOLANGCI_LINT_VERSION="2.9.0"
 OPM_VERSION="v1.60.0"
 GRPCURL_VERSION="1.7.0"
 DEPENDENCY=${1:-}

--- a/build/bin/upload
+++ b/build/bin/upload
@@ -72,10 +72,12 @@ if [ "${obfuscate}" = "true" ]; then
   if [ -n "${obfuscate_config}" ]; then
     config_args=(--config "$obfuscate_config")
   fi
+  OBFUSCATION_LOG="${must_gather_upload}/obfuscation.log"
   /usr/local/bin/must-gather-operator obfuscate \
     --input "$must_gather_output" \
     --output "${must_gather_upload}/cleaned" \
-    "${config_args[@]}" -v=3
+    "${config_args[@]}" -v=3 2>&1 | tee "${OBFUSCATION_LOG}"
+  cp "${OBFUSCATION_LOG}" "${must_gather_upload}/cleaned/obfuscation.log" 2>/dev/null || true
   echo "Obfuscation complete."
   must_gather_output="${must_gather_upload}/cleaned"
 fi

--- a/build/bin/upload
+++ b/build/bin/upload
@@ -74,7 +74,7 @@ if [ "${obfuscate}" = "true" ]; then
   fi
   OBFUSCATION_LOG="${must_gather_upload}/obfuscation.log"
   obfuscate_rc=0
-  (/usr/local/bin/must-gather-operator obfuscate \
+  (set +e; /usr/local/bin/must-gather-operator obfuscate \
     --input "$must_gather_output" \
     --output "${must_gather_upload}/cleaned" \
     "${config_args[@]}" -v=3 2>&1; echo $? > "${must_gather_upload}/.obfuscate_rc") | tee "${OBFUSCATION_LOG}"

--- a/build/bin/upload
+++ b/build/bin/upload
@@ -73,11 +73,17 @@ if [ "${obfuscate}" = "true" ]; then
     config_args=(--config "$obfuscate_config")
   fi
   OBFUSCATION_LOG="${must_gather_upload}/obfuscation.log"
-  /usr/local/bin/must-gather-operator obfuscate \
+  obfuscate_rc=0
+  (/usr/local/bin/must-gather-operator obfuscate \
     --input "$must_gather_output" \
     --output "${must_gather_upload}/cleaned" \
-    "${config_args[@]}" -v=3 2>&1 | tee "${OBFUSCATION_LOG}"
-  cp "${OBFUSCATION_LOG}" "${must_gather_upload}/cleaned/obfuscation.log" 2>/dev/null || true
+    "${config_args[@]}" -v=3 2>&1; echo $? > "${must_gather_upload}/.obfuscate_rc") | tee "${OBFUSCATION_LOG}"
+  obfuscate_rc=$(cat "${must_gather_upload}/.obfuscate_rc")
+  cp "${OBFUSCATION_LOG}" "${must_gather_upload}/cleaned/obfuscation.log"
+  if [ "$obfuscate_rc" -ne 0 ]; then
+    echo "Error: obfuscation failed with exit code ${obfuscate_rc}."
+    exit "$obfuscate_rc"
+  fi
   echo "Obfuscation complete."
   must_gather_output="${must_gather_upload}/cleaned"
 fi

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/must-gather-operator
 
-go 1.25.7
+go 1.26
 
 require (
 	github.com/go-logr/logr v1.4.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/must-gather-operator
 
-go 1.26
+go 1.26.0
 
 require (
 	github.com/go-logr/logr v1.4.2

--- a/images/ci/Dockerfile.coverage
+++ b/images/ci/Dockerfile.coverage
@@ -1,7 +1,7 @@
 # Build the must-gather-operator binary with coverage instrumentation.
 # This mirrors build/Dockerfile / Dockerfile.openshift but adds Go coverage flags
 # so the binary records which lines are executed during E2E tests.
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-4.22 AS builder
 
 ARG SRC_DIR=/go/src/github.com/openshift/must-gather-operator
 

--- a/images/ci/Dockerfile.coverage
+++ b/images/ci/Dockerfile.coverage
@@ -1,7 +1,7 @@
 # Build the must-gather-operator binary with coverage instrumentation.
 # This mirrors build/Dockerfile / Dockerfile.openshift but adds Go coverage flags
 # so the binary records which lines are executed during E2E tests.
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-4.22 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 AS builder
 
 ARG SRC_DIR=/go/src/github.com/openshift/must-gather-operator
 

--- a/pkg/mustgatherutil/obfuscate.go
+++ b/pkg/mustgatherutil/obfuscate.go
@@ -34,6 +34,8 @@ const (
 
 // RunObfuscate executes the obfuscate subcommand. Args are everything after "obfuscate" on the command line.
 // Returns an exit code suitable for os.Exit.
+// Obfuscation logs are emitted to stderr via klog; the caller (build/bin/upload) redirects
+// them to a file with tee so they are included in the must-gather bundle.
 func RunObfuscate(args []string) int {
 	fs := goflag.NewFlagSet("obfuscate", goflag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
@@ -53,10 +55,15 @@ func RunObfuscate(args []string) int {
 		return 1
 	}
 
+	klog.Infof("obfuscation starting: input=%s output=%s config=%s", *input, *output, *config)
+
 	if err := mgclean.Run(*config, *input, *output, true, *output, ObfuscateWorkerCount); err != nil {
-		fmt.Fprintf(os.Stderr, "obfuscation failed: %v\n", err)
+		klog.Errorf("obfuscation failed: %v", err)
+		klog.Flush()
 		return 1
 	}
 
+	klog.Infof("obfuscation completed successfully")
+	klog.Flush()
 	return 0
 }

--- a/test/e2e/must_gather_operator_test.go
+++ b/test/e2e/must_gather_operator_test.go
@@ -3840,11 +3840,12 @@ var _ = ginkgo.Describe("MustGather resource", ginkgo.Ordered, func() {
 							Image: operatorImage,
 							Command: []string{
 								"/bin/sh", "-c",
-								// List cleaned directory and check for report.yaml (obfuscation report)
-								`echo "=== PVC top-level ===" && ls -la /pvc/collections/ 2>/dev/null &&
+							// List cleaned directory and check for report.yaml and obfuscation.log
+							`echo "=== PVC top-level ===" && ls -la /pvc/collections/ 2>/dev/null &&
 echo "=== Cleaned directories ===" && find /pvc/collections -name 'cleaned' -type d 2>/dev/null &&
 echo "=== obfuscation report ===" && find /pvc/collections -name 'report.yaml' -type f 2>/dev/null | head -5 &&
-echo "=== sample obfuscated content ===" && find /pvc/collections -path '*/cleaned/*' -name '*.log' -type f -exec head -5 {} \; 2>/dev/null | head -20`,
+echo "=== obfuscation log ===" && find /pvc/collections -name 'obfuscation.log' -type f 2>/dev/null | head -5 &&
+echo "=== sample obfuscated content ===" && find /pvc/collections -path '*/cleaned/*' -name '*.log' -not -name 'obfuscation.log' -type f -exec head -5 {} \; 2>/dev/null | head -20`,
 							},
 							SecurityContext: &corev1.SecurityContext{
 								AllowPrivilegeEscalation: func() *bool { b := false; return &b }(),
@@ -3895,6 +3896,8 @@ echo "=== sample obfuscated content ===" && find /pvc/collections -path '*/clean
 				"PVC should contain a 'cleaned' directory from obfuscation")
 			Expect(logs).To(ContainSubstring("report.yaml"),
 				"PVC should contain report.yaml (obfuscation report)")
+			Expect(logs).To(ContainSubstring("obfuscation.log"),
+				"PVC should contain obfuscation.log (obfuscation logs)")
 		})
 	})
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved obfuscation logging by streaming output to a workspace log.
  * Preserved obfuscation logs in cleaned output when possible.
  * Added clearer success and failure reporting with reliable log flushing.
  * Improved verification and handling of obfuscation logs in cleaned content.

* **Chores**
  * Updated build and coverage tooling to use Go 1.26 and newer OpenShift base images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->