### PR TITLE
OCPBUGS-105595: Bump CSV version from 4.22.0 to 5.0.0 on release-5.0

### DIFF
--- a/bundle/manifests/support-log-gather-operator.package.yaml
+++ b/bundle/manifests/support-log-gather-operator.package.yaml
@@ -1,4 +1,4 @@
 packageName: support-log-gather-operator
 channels:
   - name: tech-preview
-    currentCSV: support-log-gather-operator.v4.22.0
+    currentCSV: support-log-gather-operator.v5.0.0

--- a/bundle/manifests/tech-preview/support-log-gather-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/tech-preview/support-log-gather-operator.clusterserviceversion.yaml
@@ -1,7 +1,7 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
-  name: support-log-gather-operator.v4.22.0
+  name: support-log-gather-operator.v5.0.0
   namespace: must-gather-operator
   annotations:
     categories: Monitoring, Application Runtime
@@ -12,7 +12,7 @@ metadata:
     createdAt: "2020-07-31T16:12:36Z"
     support: Red Hat
     repository: https://github.com/openshift/must-gather-operator
-    olm.skipRange: ">=4.20.0-0 <4.22.0"
+    olm.skipRange: ">=4.20.0-0 <5.0.0"
     features.operators.openshift.io/disconnected: "false"
     features.operators.openshift.io/fips-compliant: "true"
     features.operators.openshift.io/proxy-aware: "true"
@@ -55,7 +55,7 @@ spec:
       url: https://github.com/openshift/must-gather-operator
     - name: Source Repository
       url: https://github.com/openshift/must-gather-operator
-  version: 4.22.0
+  version: 5.0.0
   maturity: tech-preview
   maintainers:
     - email: aos-staff@redhat.com


### PR DESCRIPTION
Bump CSV version from 4.22.0 to 5.0.0 on the `release-5.0` branch.

Files updated:
- `bundle/manifests/support-log-gather-operator.package.yaml`: `currentCSV`
- `bundle/manifests/tech-preview/support-log-gather-operator.clusterserviceversion.yaml`: `metadata.name`, `olm.skipRange`, `spec.version`

Jira: [OCPBUGS-105595](https://redhat.atlassian.net/browse/OCPBUGS-105595)

[OCPBUGS-105595]: https://redhat.atlassian.net/browse/OCPBUGS-105595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ