### PR TITLE
OCPBUGS-104849: Added network policy related RBACs

### DIFF
--- a/bundle/manifests/stable/support-log-gather-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/stable/support-log-gather-operator.clusterserviceversion.yaml
@@ -196,6 +196,17 @@ spec:
                 - update
                 - watch
             - apiGroups:
+                - networking.k8s.io
+              resources:
+                - networkpolicies
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - update
+                - watch
+            - apiGroups:
                 - image.openshift.io
               resources:
                 - imagestreams

--- a/controllers/mustgather/mustgather_controller.go
+++ b/controllers/mustgather/mustgather_controller.go
@@ -85,6 +85,7 @@ var errImageValidation = goerror.New("image validation failed")
 //+kubebuilder:rbac:groups=image.openshift.io,resources=imagestreams,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=pods;services;services/finalizers;endpoints;persistentvolumeclaims;events;configmaps;secrets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch
+//+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;delete
 // ServiceAccount read access needed for pre-flight validation before Job creation
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to

--- a/deploy/02_must-gather-operator.ClusterRole.yaml
+++ b/deploy/02_must-gather-operator.ClusterRole.yaml
@@ -112,3 +112,14 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - update
+      - watch


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The support log gathering operator can now manage Kubernetes network policies, including creating, updating, viewing, and removing them.
  * This enables support data collection workflows that require network policy access.

* **Improvements**
  * Updated the operator’s cluster permissions consistently across supported deployment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->