### PR TITLE
MG-357: Gate upload on gather success and propagate exit codes

### DIFF
--- a/controllers/mustgather/constant.go
+++ b/controllers/mustgather/constant.go
@@ -32,8 +32,8 @@ const (
 	obfuscateConfigMountPath  = "/etc/must-gather-clean/custom-config/config.yaml"
 	obfuscateConfigMapKey     = "config.yaml"
 
-	// obfuscateChownSuffix transfers gather output ownership to the upload container UID (65534).
-	// Captures the gather exit status first, runs chown (|| true so non-root images don't
-	// cause retries), then exits with the original status so gather failures propagate.
-	obfuscateChownSuffix = "gather_rc=$?; chown -R 65534:65534 /must-gather || true; exit $gather_rc"
+	// obfuscateChownSuffix transfers gather output ownership to the upload container UID (65534)
+	// so the obfuscation binary can read the files. Uses || true so non-root images don't
+	// cause retries. Exit-code propagation is handled by gatherCommand itself.
+	obfuscateChownSuffix = "chown -R 65534:65534 /must-gather || true"
 )

--- a/controllers/mustgather/template.go
+++ b/controllers/mustgather/template.go
@@ -29,12 +29,14 @@ const (
 
 	gatherCommandBinaryAudit   = "gather_audit_logs"
 	gatherCommandBinaryNoAudit = "gather"
-	gatherCommand              = "timeout %v bash -x -c -- '/usr/bin/%v' 2>&1 | tee /must-gather/must-gather.log\n\nstatus=$?\nif [[ $status -eq 124 || $status -eq 137 ]]; then\n  echo \"Gather timed out.\"\n  exit 0\nfi | tee -a /must-gather/must-gather.log"
+	gatherCommand              = "set -o pipefail\ntimeout %v bash -x -c -- '/usr/bin/%v' 2>&1 | tee /must-gather/must-gather.log\ngather_rc=$?\nif [[ $gather_rc -eq 124 || $gather_rc -eq 137 ]]; then\n  echo \"Gather timed out.\" | tee -a /must-gather/must-gather.log\nfi\nif [[ $gather_rc -ne 0 && $gather_rc -ne 124 && $gather_rc -ne 137 ]]; then\n  echo \"Gather failed with exit code $gather_rc.\" | tee -a /must-gather/must-gather.log\n  exit $gather_rc\nfi"
 	gatherContainerName        = "gather"
 
 	// Environment variables for time-based log filtering
 	gatherEnvSince     = "MUST_GATHER_SINCE"
 	gatherEnvSinceTime = "MUST_GATHER_SINCE_TIME"
+
+	gatherSuccessMarkerFile = volumeMountPath + "/.gather-successful"
 
 	backoffLimit              = 3
 	uploadContainerName       = "upload"
@@ -49,7 +51,7 @@ const (
 	uploadEnvMustGatherOutput = "must_gather_output"
 	uploadEnvMustGatherUpload = "must_gather_upload"
 	uploadEnvFilenamePrefix   = "FILENAME_PREFIX"
-	uploadCommand             = "count=0\nuntil [ $count -gt 4 ]\ndo\n  while `pgrep -a gather > /dev/null`\n  do\n    echo \"waiting for gathers to complete ...\"\n    sleep 120\n    count=0\n  done\n  echo \"no gather is running ($count / 4)\"\n  ((count++))\n  sleep 30\ndone\n/usr/local/bin/upload"
+	uploadCommand             = "count=0\nuntil [ $count -gt 4 ]\ndo\n  while `pgrep -a gather > /dev/null`\n  do\n    echo \"waiting for gathers to complete ...\"\n    sleep 120\n    count=0\n  done\n  echo \"no gather is running ($count / 4)\"\n  ((count++))\n  sleep 30\ndone\nif [ ! -f " + gatherSuccessMarkerFile + " ]; then\n  echo \"Error: gather did not complete successfully. Skipping upload.\"\n  exit 1\nfi\n/usr/local/bin/upload"
 	uploadCommandDirect       = "/usr/local/bin/upload"
 
 	// SSH directory and known hosts file
@@ -328,27 +330,28 @@ func getGatherContainer(image string, audit bool, timeout time.Duration, storage
 		VolumeMounts: volumeMounts,
 	}
 
+	gatherExitCheck := "gather_rc=$?\nif [[ $gather_rc -ne 0 ]]; then exit $gather_rc; fi"
+	successMarker := "touch " + gatherSuccessMarkerFile
+
 	if len(command) > 0 {
+		// Wrap custom commands in bash to propagate exit codes and write
+		// the success marker that the upload container checks.
+		wrappedCmd := "\"$@\"\n" + gatherExitCheck
 		if shouldAppendObfuscateChown(obfuscate) {
-			// Wrap the custom command so chown still runs for the upload container (UID 65534).
-			// "$@" re-executes the original command+args with proper quoting preserved.
-			wrappedCmd := "\"$@\"\n" + obfuscateChownSuffix
-			container.Command = []string{"/bin/bash", "-c", wrappedCmd, "--"}
-			allArgs := make([]string, 0, len(command)+len(args))
-			allArgs = append(allArgs, command...)
-			allArgs = append(allArgs, args...)
-			container.Args = allArgs
-		} else {
-			container.Command = command
-			if len(args) > 0 {
-				container.Args = args
-			}
+			wrappedCmd += "\n" + obfuscateChownSuffix
 		}
+		wrappedCmd += "\n" + successMarker
+		container.Command = []string{"/bin/bash", "-c", wrappedCmd, "--"}
+		allArgs := make([]string, 0, len(command)+len(args))
+		allArgs = append(allArgs, command...)
+		allArgs = append(allArgs, args...)
+		container.Args = allArgs
 	} else {
 		gatherCmd := fmt.Sprintf(gatherCommand, math.Ceil(timeout.Seconds()), commandBinary)
 		if shouldAppendObfuscateChown(obfuscate) {
 			gatherCmd += "\n" + obfuscateChownSuffix
 		}
+		gatherCmd += "\n" + successMarker
 		container.Command = []string{
 			"/bin/bash",
 			"-c",

--- a/controllers/mustgather/template_test.go
+++ b/controllers/mustgather/template_test.go
@@ -226,21 +226,40 @@ func Test_getGatherContainer(t *testing.T) {
 
 			if len(tt.command) == 0 {
 				containerCommand := container.Command[2]
+				if !strings.Contains(containerCommand, "set -o pipefail") {
+					t.Fatalf("gather command missing pipefail, got %q", containerCommand)
+				}
 				if tt.audit && !strings.Contains(containerCommand, gatherCommandBinaryAudit) {
 					t.Fatalf("gather container command expected with binary %v but it wasn't present", gatherCommandBinaryAudit)
 				} else if !tt.audit && !strings.Contains(containerCommand, gatherCommandBinaryNoAudit) {
 					t.Fatalf("gather container command expected with binary %v but it wasn't present", gatherCommandBinaryNoAudit)
 				}
 				timeoutInSeconds := int(math.Ceil(tt.timeout.Seconds()))
-				if !strings.HasPrefix(containerCommand, fmt.Sprintf("timeout %d", timeoutInSeconds)) {
-					t.Fatalf("the duration was not properly added to the container command, got %v but wanted %v", strings.Split(containerCommand, " ")[1], timeoutInSeconds)
+				if !strings.Contains(containerCommand, fmt.Sprintf("timeout %d", timeoutInSeconds)) {
+					t.Fatalf("the duration was not properly added to the container command, got %v", containerCommand)
+				}
+				if !strings.Contains(containerCommand, "touch "+gatherSuccessMarkerFile) {
+					t.Fatalf("gather command missing success marker touch, got %q", containerCommand)
+				}
+				if !strings.Contains(containerCommand, "exit $gather_rc") {
+					t.Fatalf("gather command missing exit code propagation, got %q", containerCommand)
 				}
 			} else {
-				if !reflect.DeepEqual(container.Command, tt.command) {
-					t.Fatalf("expected container command %v but got %v", tt.command, container.Command)
+				if len(container.Command) < 3 || container.Command[0] != "/bin/bash" {
+					t.Fatalf("expected custom command to be wrapped in bash, got %v", container.Command)
 				}
-				if !reflect.DeepEqual(container.Args, tt.args) {
-					t.Fatalf("expected container args %v but got %v", tt.args, container.Args)
+				wrappedScript := container.Command[2]
+				if !strings.Contains(wrappedScript, "\"$@\"") {
+					t.Fatalf("expected wrapped script to contain \"$@\" passthrough, got %q", wrappedScript)
+				}
+				if !strings.Contains(wrappedScript, "touch "+gatherSuccessMarkerFile) {
+					t.Fatalf("expected wrapped script to contain success marker, got %q", wrappedScript)
+				}
+				expectedArgs := make([]string, 0, len(tt.command)+len(tt.args))
+				expectedArgs = append(expectedArgs, tt.command...)
+				expectedArgs = append(expectedArgs, tt.args...)
+				if !reflect.DeepEqual(container.Args, expectedArgs) {
+					t.Fatalf("expected container args %v but got %v", expectedArgs, container.Args)
 				}
 			}
 
@@ -664,8 +683,8 @@ func Test_getJobTemplate_ProxyAuditTimeout(t *testing.T) {
 					t.Fatalf("expected gather command to contain %v but got %v", gatherCommandBinaryNoAudit, gatherCmd)
 				}
 			}
-			if !strings.HasPrefix(gatherCmd, tt.wantTimeout) {
-				t.Fatalf("expected gather command to start with %q but got %q", tt.wantTimeout, gatherCmd)
+			if !strings.Contains(gatherCmd, tt.wantTimeout) {
+				t.Fatalf("expected gather command to contain %q but got %q", tt.wantTimeout, gatherCmd)
 			}
 
 			upload := findUploadContainerInJob(t, job)
@@ -1050,8 +1069,55 @@ func Test_getGatherContainer_ChownSuffix(t *testing.T) {
 	}
 
 	containerCustomCmdNoObfuscate := getGatherContainer("img", false, 5*time.Second, nil, "", nil, []string{"/custom"}, nil, "", nil)
-	if len(containerCustomCmdNoObfuscate.Command) != 1 || containerCustomCmdNoObfuscate.Command[0] != "/custom" {
-		t.Fatalf("expected custom command to be preserved without obfuscate, got %v", containerCustomCmdNoObfuscate.Command)
+	if len(containerCustomCmdNoObfuscate.Command) < 3 || containerCustomCmdNoObfuscate.Command[0] != "/bin/bash" {
+		t.Fatalf("expected custom command without obfuscate to be wrapped in bash for success marker, got %v", containerCustomCmdNoObfuscate.Command)
+	}
+	noObfuscateScript := containerCustomCmdNoObfuscate.Command[2]
+	if !strings.Contains(noObfuscateScript, "touch "+gatherSuccessMarkerFile) {
+		t.Fatalf("expected success marker in custom command without obfuscate, got %q", noObfuscateScript)
+	}
+	if strings.Contains(noObfuscateScript, obfuscateChownSuffix) {
+		t.Fatalf("expected no chown suffix in custom command without obfuscate, got %q", noObfuscateScript)
+	}
+	if !reflect.DeepEqual(containerCustomCmdNoObfuscate.Args, []string{"/custom"}) {
+		t.Fatalf("expected args [/custom], got %v", containerCustomCmdNoObfuscate.Args)
+	}
+}
+
+func Test_gatherCommand_ExitCodePropagation(t *testing.T) {
+	container := getGatherContainer("img", false, 30*time.Second, nil, "", nil, nil, nil, "", nil)
+	cmd := container.Command[2]
+
+	if !strings.Contains(cmd, "set -o pipefail") {
+		t.Fatalf("gather command must include pipefail to propagate gather exit code through tee pipe")
+	}
+	if !strings.Contains(cmd, "gather_rc=$?") {
+		t.Fatalf("gather command must capture exit code into gather_rc")
+	}
+	if !strings.Contains(cmd, "exit $gather_rc") {
+		t.Fatalf("gather command must exit with gather_rc on non-timeout failure")
+	}
+	if !strings.Contains(cmd, "touch "+gatherSuccessMarkerFile) {
+		t.Fatalf("gather command must write success marker on completion")
+	}
+
+	// Timeout (124/137) should not trigger the failure exit path
+	if strings.Contains(cmd, "gather_rc -ne 0 ]]; then") && !strings.Contains(cmd, "gather_rc -ne 124") {
+		t.Fatalf("gather command must exclude timeout codes (124/137) from the failure exit")
+	}
+}
+
+func Test_uploadCommand_GatherSuccessGating(t *testing.T) {
+	if !strings.Contains(uploadCommand, gatherSuccessMarkerFile) {
+		t.Fatalf("uploadCommand must check for gather success marker file, got %q", uploadCommand)
+	}
+	if !strings.Contains(uploadCommand, "exit 1") {
+		t.Fatalf("uploadCommand must exit 1 when gather marker is missing")
+	}
+
+	// uploadCommandDirect (obfuscate.source mode) must NOT check the marker
+	if strings.Contains(uploadCommandDirect, gatherSuccessMarkerFile) {
+		t.Fatalf("uploadCommandDirect must not check gather success marker (no gather in source mode)")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fix gather container always exiting 0 regardless of gather outcome by adding `set -o pipefail` and properly capturing the gather exit code (not tee's)
- Gate the upload container on a `.gather-successful` marker file written by the gather container on successful completion
- Wrap custom gather commands in bash to propagate exit codes and write the success marker
- Simplify `obfuscateChownSuffix` since exit-code propagation is now handled by `gatherCommand` itself

### Root Cause

Three independent bugs combined to let partial/failed gather output be uploaded:

1. `gatherCommand`: `timeout ... | tee ...` without `pipefail` meant `$?` always reflected `tee`'s exit (0), not gather's. Additionally, `fi | tee -a` created a subshell so `exit 0` only exited that subshell.
2. `uploadCommand`: After pgrep debounce, upload ran unconditionally — no success check.
3. Custom commands were passed through unmodified with no exit-code signaling.

### Behavior After Fix

| Scenario | Gather Container | Upload Container | Job Status |
|----------|-----------------|-----------------|------------|
| Gather succeeds | Writes `.gather-successful`, exits 0 | Finds marker, proceeds with obfuscation/upload | Completed |
| Gather times out (124/137) | Writes marker, exits 0 (partial success) | Finds marker, proceeds | Completed |
| Gather fails (other non-zero) | Exits with failure code, no marker | Finds no marker, exits 1, skips upload | Failed |
| Gather crashes | No marker written | Finds no marker, exits 1, skips upload | Failed |
| obfuscate.source (no gather) | N/A | Uses `uploadCommandDirect`, no marker check | Completed |

## Test plan

- [x] `Test_gatherCommand_ExitCodePropagation`: pipefail, exit-code capture, failure exit, timeout exclusion, marker file touch
- [x] `Test_uploadCommand_GatherSuccessGating`: upload command checks marker; `uploadCommandDirect` does not
- [x] Updated `Test_getGatherContainer`: default commands include pipefail and marker; custom commands wrapped in bash
- [x] Updated `Test_getGatherContainer_ChownSuffix`: custom commands without obfuscate are now wrapped for marker
- [x] Updated `Test_getJobTemplate_ProxyAuditTimeout`: relaxed prefix check to contains check (pipefail prefix)
- [x] All existing tests pass: `go test ./controllers/mustgather/`
- [ ] Integration: Create MustGather CR with SFTP target, simulate gather failure, verify no upload and CR shows Failed
- [ ] Integration: Verify normal gather → obfuscate → upload flow still works end-to-end

Always review AI generated responses prior to use.
Generated with [Claude Code](https://claude.com/claude-code) via openshift-developer plugin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Gather failures and timeouts are now reported accurately, with exit statuses preserved.
  - Uploads are prevented when gathering does not complete successfully.
  - Custom gather commands now consistently preserve arguments and failure statuses.
  - Successful gathers are explicitly verified before upload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->