### PR TITLE
MG-360: Bumped base image version

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -16,7 +16,7 @@ COPY . /src
 
 RUN make go-build
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1760515502
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1787647261
 ENV OPERATOR=/usr/local/bin/must-gather-operator \
     OPERATOR_BIN=must-gather-operator \
     USER_UID=1001 \

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1760515502
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1787647261
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe


### PR DESCRIPTION
## Summary
- Bumped UBI base image from `9.6-1760515502` to `9.8-1787647261` in `build/Dockerfile` and `build/Dockerfile.olm-registry`
- Addresses CVE-2026-48864

## Test plan
- [ ] Verify operator image builds successfully with the updated base image
- [ ] Confirm no runtime regressions from the base image update


Made with [Cursor](https://cursor.com)