### PR TITLE
[release-5.0] MG-183: Add namespace restrictions for must-gather jobs

### DIFF
--- a/bundle/manifests/stable/support-log-gather-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/stable/support-log-gather-operator.clusterserviceversion.yaml
@@ -214,6 +214,42 @@ spec:
                 - get
                 - list
                 - watch
+            - apiGroups:
+                - admissionregistration.k8s.io
+              resources:
+                - validatingadmissionpolicies
+              verbs:
+                - create
+            - apiGroups:
+                - admissionregistration.k8s.io
+              resources:
+                - validatingadmissionpolicies
+              resourceNames:
+                - block-mustgather-restricted-namespaces
+              verbs:
+                - get
+                - list
+                - watch
+                - update
+                - patch
+            - apiGroups:
+                - admissionregistration.k8s.io
+              resources:
+                - validatingadmissionpolicybindings
+              verbs:
+                - create
+            - apiGroups:
+                - admissionregistration.k8s.io
+              resources:
+                - validatingadmissionpolicybindings
+              resourceNames:
+                - block-mustgather-restricted-namespaces
+              verbs:
+                - get
+                - list
+                - watch
+                - update
+                - patch
       deployments:
         - name: must-gather-operator
           spec:

--- a/controllers/mustgather/admission_policy.go
+++ b/controllers/mustgather/admission_policy.go
@@ -1,0 +1,128 @@
+package mustgather
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const blockMustGatherRestrictedNamespacesPolicyName = "block-mustgather-restricted-namespaces"
+
+func blockMustGatherRestrictedNamespacesPolicy() *admissionregistrationv1.ValidatingAdmissionPolicy {
+	failurePolicy := admissionregistrationv1.Fail
+	return &admissionregistrationv1.ValidatingAdmissionPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: blockMustGatherRestrictedNamespacesPolicyName,
+		},
+		Spec: admissionregistrationv1.ValidatingAdmissionPolicySpec{
+			FailurePolicy: &failurePolicy,
+			MatchConstraints: &admissionregistrationv1.MatchResources{
+				ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{
+					{
+						RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+							Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+							Rule: admissionregistrationv1.Rule{
+								APIGroups:   []string{"operator.openshift.io"},
+								APIVersions: []string{"v1alpha1", "v1"},
+								Resources:   []string{"mustgathers"},
+							},
+						},
+					},
+				},
+			},
+			Validations: []admissionregistrationv1.Validation{
+				{
+					Expression: "object.metadata.namespace != 'openshift'",
+					Message:    "MustGather resources cannot be created in the openshift namespace.",
+				},
+				{
+					Expression: "!object.metadata.namespace.startsWith('openshift-')",
+					Message:    "MustGather resources cannot be created in openshift-* namespaces.",
+				},
+				{
+					Expression: "object.metadata.namespace != 'kube'",
+					Message:    "MustGather resources cannot be created in the kube namespace.",
+				},
+				{
+					Expression: "!object.metadata.namespace.startsWith('kube-')",
+					Message:    "MustGather resources cannot be created in kube-* namespaces.",
+				},
+				{
+					Expression: "object.metadata.namespace != 'hypershift'",
+					Message:    "MustGather resources cannot be created in the hypershift namespace.",
+				},
+				{
+					Expression: "!object.metadata.namespace.startsWith('hypershift-')",
+					Message:    "MustGather resources cannot be created in hypershift-* namespaces.",
+				},
+			},
+		},
+	}
+}
+
+func blockMustGatherRestrictedNamespacesPolicyBinding() *admissionregistrationv1.ValidatingAdmissionPolicyBinding {
+	return &admissionregistrationv1.ValidatingAdmissionPolicyBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: blockMustGatherRestrictedNamespacesPolicyName,
+		},
+		Spec: admissionregistrationv1.ValidatingAdmissionPolicyBindingSpec{
+			PolicyName:        blockMustGatherRestrictedNamespacesPolicyName,
+			ValidationActions: []admissionregistrationv1.ValidationAction{admissionregistrationv1.Deny},
+		},
+	}
+}
+
+func (r *MustGatherReconciler) ensureAdmissionPolicy(ctx context.Context, c client.Client, reader client.Reader) error {
+	setupLog := log.WithName("admission-policy")
+
+	if err := r.ensureVAP(ctx, c, reader, setupLog); err != nil {
+		setupLog.Error(err, "failed to ensure ValidatingAdmissionPolicy (non-fatal)")
+	}
+
+	if err := r.ensureVAPBinding(ctx, c, reader, setupLog); err != nil {
+		setupLog.Error(err, "failed to ensure ValidatingAdmissionPolicyBinding (non-fatal)")
+	}
+
+	return nil
+}
+
+func (r *MustGatherReconciler) ensureVAP(ctx context.Context, c client.Client, reader client.Reader, setupLog logr.Logger) error {
+	vap := blockMustGatherRestrictedNamespacesPolicy()
+
+	existing := &admissionregistrationv1.ValidatingAdmissionPolicy{}
+	err := reader.Get(ctx, client.ObjectKeyFromObject(vap), existing)
+	if errors.IsNotFound(err) {
+		setupLog.Info("creating ValidatingAdmissionPolicy", "name", vap.Name)
+		return c.Create(ctx, vap)
+	} else if err != nil {
+		return err
+	} else if !equality.Semantic.DeepEqual(existing.Spec, vap.Spec) {
+		setupLog.Info("updating ValidatingAdmissionPolicy", "name", vap.Name)
+		existing.Spec = vap.Spec
+		return c.Update(ctx, existing)
+	}
+	return nil
+}
+
+func (r *MustGatherReconciler) ensureVAPBinding(ctx context.Context, c client.Client, reader client.Reader, setupLog logr.Logger) error {
+	binding := blockMustGatherRestrictedNamespacesPolicyBinding()
+
+	existingBinding := &admissionregistrationv1.ValidatingAdmissionPolicyBinding{}
+	err := reader.Get(ctx, client.ObjectKeyFromObject(binding), existingBinding)
+	if errors.IsNotFound(err) {
+		setupLog.Info("creating ValidatingAdmissionPolicyBinding", "name", binding.Name)
+		return c.Create(ctx, binding)
+	} else if err != nil {
+		return err
+	} else if !equality.Semantic.DeepEqual(existingBinding.Spec, binding.Spec) {
+		setupLog.Info("updating ValidatingAdmissionPolicyBinding", "name", binding.Name)
+		existingBinding.Spec = binding.Spec
+		return c.Update(ctx, existingBinding)
+	}
+	return nil
+}

--- a/controllers/mustgather/admission_policy_test.go
+++ b/controllers/mustgather/admission_policy_test.go
@@ -1,0 +1,243 @@
+package mustgather
+
+import (
+	"context"
+	"testing"
+
+	"github.com/redhat-cop/operator-utils/pkg/util"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func newAdmissionPolicyReconciler(t *testing.T, objects []client.Object) *MustGatherReconciler {
+	t.Helper()
+
+	s := runtime.NewScheme()
+	if err := admissionregistrationv1.AddToScheme(s); err != nil {
+		t.Fatalf("add admissionregistrationv1 to scheme: %v", err)
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(objects...).Build()
+	return &MustGatherReconciler{
+		ReconcilerBase: util.NewReconcilerBase(cl, s, &rest.Config{}, &record.FakeRecorder{}, nil),
+	}
+}
+
+func TestBlockMustGatherRestrictedNamespacesPolicy(t *testing.T) {
+	vap := blockMustGatherRestrictedNamespacesPolicy()
+
+	if vap.Name != "block-mustgather-restricted-namespaces" {
+		t.Fatalf("expected policy name %q, got %q", "block-mustgather-restricted-namespaces", vap.Name)
+	}
+
+	if vap.Spec.FailurePolicy == nil || *vap.Spec.FailurePolicy != admissionregistrationv1.Fail {
+		t.Fatal("expected failurePolicy to be Fail")
+	}
+
+	if vap.Spec.MatchConstraints == nil {
+		t.Fatal("expected matchConstraints to be set")
+	}
+	if len(vap.Spec.MatchConstraints.ResourceRules) != 1 {
+		t.Fatalf("expected 1 resourceRule, got %d", len(vap.Spec.MatchConstraints.ResourceRules))
+	}
+
+	rule := vap.Spec.MatchConstraints.ResourceRules[0]
+	if len(rule.Operations) != 1 || rule.Operations[0] != admissionregistrationv1.Create {
+		t.Fatalf("expected single CREATE operation, got %v", rule.Operations)
+	}
+	if len(rule.APIGroups) != 1 || rule.APIGroups[0] != "operator.openshift.io" {
+		t.Fatalf("expected apiGroup operator.openshift.io, got %v", rule.APIGroups)
+	}
+	expectedVersions := []string{"v1alpha1", "v1"}
+	if len(rule.APIVersions) != len(expectedVersions) {
+		t.Fatalf("expected apiVersions %v, got %v", expectedVersions, rule.APIVersions)
+	}
+	for i, v := range expectedVersions {
+		if rule.APIVersions[i] != v {
+			t.Fatalf("expected apiVersions[%d] = %q, got %q", i, v, rule.APIVersions[i])
+		}
+	}
+	if len(rule.Resources) != 1 || rule.Resources[0] != "mustgathers" {
+		t.Fatalf("expected resource mustgathers, got %v", rule.Resources)
+	}
+
+	if len(vap.Spec.Validations) != 6 {
+		t.Fatalf("expected 6 validations, got %d", len(vap.Spec.Validations))
+	}
+
+	expectedExpressions := []string{
+		"object.metadata.namespace != 'openshift'",
+		"!object.metadata.namespace.startsWith('openshift-')",
+		"object.metadata.namespace != 'kube'",
+		"!object.metadata.namespace.startsWith('kube-')",
+		"object.metadata.namespace != 'hypershift'",
+		"!object.metadata.namespace.startsWith('hypershift-')",
+	}
+	for i, expected := range expectedExpressions {
+		if vap.Spec.Validations[i].Expression != expected {
+			t.Errorf("validation[%d]: expected expression %q, got %q", i, expected, vap.Spec.Validations[i].Expression)
+		}
+	}
+}
+
+func TestBlockMustGatherRestrictedNamespacesPolicyBinding(t *testing.T) {
+	binding := blockMustGatherRestrictedNamespacesPolicyBinding()
+
+	if binding.Name != "block-mustgather-restricted-namespaces" {
+		t.Fatalf("expected binding name %q, got %q", "block-mustgather-restricted-namespaces", binding.Name)
+	}
+	if binding.Spec.PolicyName != "block-mustgather-restricted-namespaces" {
+		t.Fatalf("expected policyName %q, got %q", "block-mustgather-restricted-namespaces", binding.Spec.PolicyName)
+	}
+	if len(binding.Spec.ValidationActions) != 1 || binding.Spec.ValidationActions[0] != admissionregistrationv1.Deny {
+		t.Fatalf("expected single Deny validationAction, got %v", binding.Spec.ValidationActions)
+	}
+}
+
+func TestEnsureVAP(t *testing.T) {
+	tests := []struct {
+		name      string
+		objects   []client.Object
+		postCheck func(t *testing.T, cl client.Client)
+	}{
+		{
+			name:    "creates when missing",
+			objects: nil,
+			postCheck: func(t *testing.T, cl client.Client) {
+				vap := &admissionregistrationv1.ValidatingAdmissionPolicy{}
+				if err := cl.Get(context.TODO(), client.ObjectKey{Name: blockMustGatherRestrictedNamespacesPolicyName}, vap); err != nil {
+					t.Fatalf("expected VAP to be created, got: %v", err)
+				}
+				if len(vap.Spec.Validations) != 6 {
+					t.Fatalf("expected 6 validations, got %d", len(vap.Spec.Validations))
+				}
+			},
+		},
+		{
+			name: "updates when spec differs",
+			objects: []client.Object{
+				&admissionregistrationv1.ValidatingAdmissionPolicy{
+					ObjectMeta: metav1.ObjectMeta{Name: blockMustGatherRestrictedNamespacesPolicyName},
+					Spec: admissionregistrationv1.ValidatingAdmissionPolicySpec{
+						Validations: []admissionregistrationv1.Validation{
+							{Expression: "true", Message: "placeholder"},
+						},
+					},
+				},
+			},
+			postCheck: func(t *testing.T, cl client.Client) {
+				vap := &admissionregistrationv1.ValidatingAdmissionPolicy{}
+				if err := cl.Get(context.TODO(), client.ObjectKey{Name: blockMustGatherRestrictedNamespacesPolicyName}, vap); err != nil {
+					t.Fatalf("expected VAP to exist: %v", err)
+				}
+				if len(vap.Spec.Validations) != 6 {
+					t.Fatalf("expected spec to be updated to 6 validations, got %d", len(vap.Spec.Validations))
+				}
+			},
+		},
+		{
+			name: "no-op when unchanged",
+			objects: func() []client.Object {
+				return []client.Object{blockMustGatherRestrictedNamespacesPolicy()}
+			}(),
+			postCheck: func(t *testing.T, cl client.Client) {
+				vap := &admissionregistrationv1.ValidatingAdmissionPolicy{}
+				if err := cl.Get(context.TODO(), client.ObjectKey{Name: blockMustGatherRestrictedNamespacesPolicyName}, vap); err != nil {
+					t.Fatalf("expected VAP to exist: %v", err)
+				}
+				if len(vap.Spec.Validations) != 6 {
+					t.Fatalf("expected 6 validations, got %d", len(vap.Spec.Validations))
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newAdmissionPolicyReconciler(t, tt.objects)
+			err := r.ensureVAP(context.TODO(), r.GetClient(), r.GetClient(), logf.Log)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			tt.postCheck(t, r.GetClient())
+		})
+	}
+}
+
+func TestEnsureVAPBinding(t *testing.T) {
+	tests := []struct {
+		name      string
+		objects   []client.Object
+		postCheck func(t *testing.T, cl client.Client)
+	}{
+		{
+			name:    "creates when missing",
+			objects: nil,
+			postCheck: func(t *testing.T, cl client.Client) {
+				binding := &admissionregistrationv1.ValidatingAdmissionPolicyBinding{}
+				if err := cl.Get(context.TODO(), client.ObjectKey{Name: blockMustGatherRestrictedNamespacesPolicyName}, binding); err != nil {
+					t.Fatalf("expected binding to be created, got: %v", err)
+				}
+				if binding.Spec.PolicyName != blockMustGatherRestrictedNamespacesPolicyName {
+					t.Fatalf("expected policyName %q, got %q", blockMustGatherRestrictedNamespacesPolicyName, binding.Spec.PolicyName)
+				}
+			},
+		},
+		{
+			name: "updates when spec differs",
+			objects: []client.Object{
+				&admissionregistrationv1.ValidatingAdmissionPolicyBinding{
+					ObjectMeta: metav1.ObjectMeta{Name: blockMustGatherRestrictedNamespacesPolicyName},
+					Spec: admissionregistrationv1.ValidatingAdmissionPolicyBindingSpec{
+						PolicyName:        "wrong-policy",
+						ValidationActions: []admissionregistrationv1.ValidationAction{admissionregistrationv1.Warn},
+					},
+				},
+			},
+			postCheck: func(t *testing.T, cl client.Client) {
+				binding := &admissionregistrationv1.ValidatingAdmissionPolicyBinding{}
+				if err := cl.Get(context.TODO(), client.ObjectKey{Name: blockMustGatherRestrictedNamespacesPolicyName}, binding); err != nil {
+					t.Fatalf("expected binding to exist: %v", err)
+				}
+				if binding.Spec.PolicyName != blockMustGatherRestrictedNamespacesPolicyName {
+					t.Fatalf("expected policyName to be updated, got %q", binding.Spec.PolicyName)
+				}
+				if len(binding.Spec.ValidationActions) != 1 || binding.Spec.ValidationActions[0] != admissionregistrationv1.Deny {
+					t.Fatalf("expected Deny action, got %v", binding.Spec.ValidationActions)
+				}
+			},
+		},
+		{
+			name: "no-op when unchanged",
+			objects: func() []client.Object {
+				return []client.Object{blockMustGatherRestrictedNamespacesPolicyBinding()}
+			}(),
+			postCheck: func(t *testing.T, cl client.Client) {
+				binding := &admissionregistrationv1.ValidatingAdmissionPolicyBinding{}
+				if err := cl.Get(context.TODO(), client.ObjectKey{Name: blockMustGatherRestrictedNamespacesPolicyName}, binding); err != nil {
+					t.Fatalf("expected binding to exist: %v", err)
+				}
+				if binding.Spec.PolicyName != blockMustGatherRestrictedNamespacesPolicyName {
+					t.Fatalf("expected policyName %q, got %q", blockMustGatherRestrictedNamespacesPolicyName, binding.Spec.PolicyName)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newAdmissionPolicyReconciler(t, tt.objects)
+			err := r.ensureVAPBinding(context.TODO(), r.GetClient(), r.GetClient(), logf.Log)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			tt.postCheck(t, r.GetClient())
+		})
+	}
+}

--- a/controllers/mustgather/mustgather_controller.go
+++ b/controllers/mustgather/mustgather_controller.go
@@ -41,6 +41,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -88,6 +89,10 @@ var errImageValidation = goerror.New("image validation failed")
 //+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch
 //+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;delete
 // ServiceAccount read access needed for pre-flight validation before Job creation
+//+kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingadmissionpolicies,verbs=create
+//+kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingadmissionpolicies,resourceNames=block-mustgather-restricted-namespaces,verbs=get;list;watch;update;patch
+//+kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingadmissionpolicybindings,verbs=create
+//+kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingadmissionpolicybindings,resourceNames=block-mustgather-restricted-namespaces,verbs=get;list;watch;update;patch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -162,11 +167,7 @@ func (r *MustGatherReconciler) Reconcile(ctx context.Context, request reconcile.
 	if instance.Namespace == r.OperatorNamespace && saName == r.OperatorServiceAccountName {
 		validationErr := fmt.Errorf("serviceAccountName %q is not allowed in namespace %q: the operator's own service account cannot be used for must-gather jobs", saName, instance.Namespace)
 		reqLogger.Error(validationErr, "operator service account usage rejected", "name", saName, "namespace", instance.Namespace, "operatorNamespace", r.OperatorNamespace)
-		result, statusErr := r.setValidationFailureStatus(ctx, reqLogger, instance, ValidationServiceAccount, validationErr)
-		if statusErr != nil {
-			return result, statusErr
-		}
-		return result, nil
+		return r.setValidationFailureStatus(ctx, reqLogger, instance, ValidationServiceAccount, validationErr)
 	}
 
 	// perform CA config map copy, iff set in caller
@@ -397,6 +398,12 @@ func (r *MustGatherReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	if r.TrustedCAConfigMap != "" {
 		b = b.Owns(&corev1.ConfigMap{}, builder.WithPredicates(isNameEquals(r.TrustedCAConfigMap)))
+	}
+
+	if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
+		return r.ensureAdmissionPolicy(ctx, mgr.GetClient(), mgr.GetAPIReader())
+	})); err != nil {
+		return fmt.Errorf("failed to add admission policy runnable: %w", err)
 	}
 
 	return b.Complete(r)

--- a/deploy/02_must-gather-operator.ClusterRole.yaml
+++ b/deploy/02_must-gather-operator.ClusterRole.yaml
@@ -112,6 +112,43 @@ rules:
       - get
       - list
       - watch
+  # namespace restriction admission policy
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingadmissionpolicies
+    verbs:
+      - create
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingadmissionpolicies
+    resourceNames:
+      - block-mustgather-restricted-namespaces
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingadmissionpolicybindings
+    verbs:
+      - create
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingadmissionpolicybindings
+    resourceNames:
+      - block-mustgather-restricted-namespaces
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
   - apiGroups:
       - networking.k8s.io
     resources:

--- a/test/e2e/must_gather_operator_test.go
+++ b/test/e2e/must_gather_operator_test.go
@@ -28,6 +28,7 @@ import (
 	mustgatherv1 "github.com/openshift/must-gather-operator/api/v1"
 	mustgatherv1alpha1 "github.com/openshift/must-gather-operator/api/v1alpha1"
 
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -138,6 +139,7 @@ var (
 
 func init() {
 	testScheme = k8sruntime.NewScheme()
+	utilruntime.Must(admissionregistrationv1.AddToScheme(testScheme))
 	utilruntime.Must(mustgatherv1.AddToScheme(testScheme))
 	utilruntime.Must(mustgatherv1alpha1.AddToScheme(testScheme))
 	utilruntime.Must(appsv1.AddToScheme(testScheme))
@@ -3397,6 +3399,257 @@ var _ = ginkgo.Describe("MustGather resource", ginkgo.Ordered, func() {
 		})
 	})
 
+	ginkgo.Context("Namespace Restriction Tests", ginkgo.Ordered, func() {
+		const (
+			vapName     = "block-mustgather-restricted-namespaces"
+			vapBindName = "block-mustgather-restricted-namespaces"
+		)
+
+		var mustGatherName string
+
+		ginkgo.BeforeAll(func() {
+			ginkgo.By("Waiting for ValidatingAdmissionPolicy to be deployed by the operator")
+			vap := &admissionregistrationv1.ValidatingAdmissionPolicy{}
+			Eventually(func() error {
+				return adminClient.Get(testCtx, client.ObjectKey{Name: vapName}, vap)
+			}).WithTimeout(2*time.Minute).WithPolling(5*time.Second).Should(Succeed(),
+				"ValidatingAdmissionPolicy %q should be created by the operator", vapName)
+
+			ginkgo.By("Waiting for ValidatingAdmissionPolicyBinding to be deployed by the operator")
+			binding := &admissionregistrationv1.ValidatingAdmissionPolicyBinding{}
+			Eventually(func() error {
+				return adminClient.Get(testCtx, client.ObjectKey{Name: vapBindName}, binding)
+			}).WithTimeout(2*time.Minute).WithPolling(5*time.Second).Should(Succeed(),
+				"ValidatingAdmissionPolicyBinding %q should be created by the operator", vapBindName)
+		})
+
+		ginkgo.BeforeEach(func() {
+			mustGatherName = fmt.Sprintf("vap-ns-restrict-%d", time.Now().UnixNano())
+		})
+
+		assertRejectedWithNoWorkloads := func(namespace, expectedErrSubstring string, createErr error) {
+			Expect(createErr).To(HaveOccurred(), "VAP should reject MustGather in namespace %q", namespace)
+			Expect(apierrors.IsForbidden(createErr) || apierrors.IsInvalid(createErr)).To(BeTrue(),
+				"expected Forbidden or Invalid from VAP denial, got: %v", createErr)
+			Expect(createErr.Error()).To(ContainSubstring(expectedErrSubstring),
+				"error should mention the restricted namespace %q", expectedErrSubstring)
+
+			ginkgo.By(fmt.Sprintf("Verifying MustGather CR was not persisted in %s", namespace))
+			mgErr := adminClient.Get(testCtx, client.ObjectKey{Name: mustGatherName, Namespace: namespace}, &mustgatherv1.MustGather{})
+			Expect(apierrors.IsNotFound(mgErr)).To(BeTrue(),
+				"MustGather CR should not exist after VAP rejection in %s, got: %v", namespace, mgErr)
+
+			ginkgo.By(fmt.Sprintf("Verifying no Job was created in %s", namespace))
+			Consistently(func() bool {
+				jobErr := adminClient.Get(testCtx, client.ObjectKey{Name: mustGatherName, Namespace: namespace}, &batchv1.Job{})
+				return apierrors.IsNotFound(jobErr)
+			}).WithTimeout(30*time.Second).WithPolling(5*time.Second).Should(BeTrue(),
+				"Job should not be created after VAP rejection in %s", namespace)
+
+			ginkgo.By(fmt.Sprintf("Verifying no Pods were created for rejected MustGather in %s", namespace))
+			podList := &corev1.PodList{}
+			Expect(adminClient.List(testCtx, podList,
+				client.InNamespace(namespace),
+				client.MatchingLabels{jobNameLabelKey: mustGatherName})).To(Succeed())
+			Expect(podList.Items).To(BeEmpty(),
+				"no pods should exist for rejected MustGather %s in %s", mustGatherName, namespace)
+		}
+
+		ginkgo.It("should verify ValidatingAdmissionPolicy and binding are deployed", func() {
+			ginkgo.By("Checking that the ValidatingAdmissionPolicy exists")
+			vap := &admissionregistrationv1.ValidatingAdmissionPolicy{}
+			err := adminClient.Get(testCtx, client.ObjectKey{Name: vapName}, vap)
+			Expect(err).NotTo(HaveOccurred(), "ValidatingAdmissionPolicy %q should exist", vapName)
+			Expect(vap.Spec.MatchConstraints).NotTo(BeNil(), "VAP should have matchConstraints")
+			Expect(vap.Spec.FailurePolicy).NotTo(BeNil(), "VAP should set failurePolicy")
+			Expect(*vap.Spec.FailurePolicy).To(Equal(admissionregistrationv1.Fail),
+				"VAP failurePolicy should be Fail")
+			Expect(vap.Spec.Validations).To(HaveLen(6), "VAP should have 6 validation expressions")
+
+			expressions := make([]string, 0, len(vap.Spec.Validations))
+			for _, validation := range vap.Spec.Validations {
+				expressions = append(expressions, validation.Expression)
+			}
+			Expect(expressions).To(ContainElements(
+				"object.metadata.namespace != 'openshift'",
+				"!object.metadata.namespace.startsWith('openshift-')",
+				"object.metadata.namespace != 'kube'",
+				"!object.metadata.namespace.startsWith('kube-')",
+				"object.metadata.namespace != 'hypershift'",
+				"!object.metadata.namespace.startsWith('hypershift-')",
+			), "VAP should include the expected namespace restriction expressions")
+
+			Expect(vap.Spec.MatchConstraints.ResourceRules).NotTo(BeEmpty(), "VAP should have resourceRules")
+			rule := vap.Spec.MatchConstraints.ResourceRules[0]
+			Expect(rule.APIGroups).To(ContainElement("operator.openshift.io"))
+			Expect(rule.APIVersions).To(ContainElements("v1alpha1", "v1"))
+			Expect(rule.Resources).To(ContainElement("mustgathers"))
+			Expect(rule.Operations).To(ContainElement(admissionregistrationv1.Create))
+
+			ginkgo.By("Checking that the ValidatingAdmissionPolicyBinding exists")
+			binding := &admissionregistrationv1.ValidatingAdmissionPolicyBinding{}
+			err = adminClient.Get(testCtx, client.ObjectKey{Name: vapBindName}, binding)
+			Expect(err).NotTo(HaveOccurred(), "ValidatingAdmissionPolicyBinding %q should exist", vapBindName)
+			Expect(binding.Spec.PolicyName).To(Equal(vapName), "Binding should reference the correct policy")
+			Expect(binding.Spec.ValidationActions).To(ContainElement(admissionregistrationv1.Deny),
+				"Binding should deny violating requests")
+		})
+
+		ginkgo.It("should reject MustGather creation in openshift-* namespaces", func() {
+			ginkgo.By("Attempting to create a MustGather CR in openshift-monitoring")
+			mg := &mustgatherv1.MustGather{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      mustGatherName,
+					Namespace: "openshift-monitoring",
+				},
+				Spec: mustgatherv1.MustGatherSpec{
+					ServiceAccountName: "default",
+				},
+			}
+			assertRejectedWithNoWorkloads("openshift-monitoring", "openshift-", adminClient.Create(testCtx, mg))
+		})
+
+		ginkgo.It("should reject MustGather creation in kube-* namespaces", func() {
+			ginkgo.By("Attempting to create a MustGather CR in kube-system")
+			mg := &mustgatherv1.MustGather{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      mustGatherName,
+					Namespace: "kube-system",
+				},
+				Spec: mustgatherv1.MustGatherSpec{
+					ServiceAccountName: "default",
+				},
+			}
+			assertRejectedWithNoWorkloads("kube-system", "kube-", adminClient.Create(testCtx, mg))
+		})
+
+		ginkgo.It("should reject MustGather creation in hypershift-* namespaces", func() {
+			hypershiftNs := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "hypershift-e2e-test",
+				},
+			}
+
+			ginkgo.By("Creating hypershift-e2e-test namespace")
+			err := adminClient.Create(testCtx, hypershiftNs)
+			if err != nil && !apierrors.IsAlreadyExists(err) {
+				Expect(err).NotTo(HaveOccurred(), "Failed to create hypershift test namespace")
+			}
+			defer func() {
+				_ = adminClient.Delete(testCtx, hypershiftNs)
+			}()
+
+			ginkgo.By("Attempting to create a MustGather CR in hypershift-e2e-test")
+			mg := &mustgatherv1.MustGather{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      mustGatherName,
+					Namespace: "hypershift-e2e-test",
+				},
+				Spec: mustgatherv1.MustGatherSpec{
+					ServiceAccountName: "default",
+				},
+			}
+			assertRejectedWithNoWorkloads("hypershift-e2e-test", "hypershift-", adminClient.Create(testCtx, mg))
+		})
+
+		ginkgo.It("should reject MustGather creation in bare openshift namespace", func() {
+			openshiftNs := &corev1.Namespace{}
+			nsCreated := false
+
+			ginkgo.By("Ensuring the openshift namespace exists")
+			err := adminClient.Get(testCtx, client.ObjectKey{Name: "openshift"}, openshiftNs)
+			if apierrors.IsNotFound(err) {
+				openshiftNs = &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{Name: "openshift"},
+				}
+				Expect(adminClient.Create(testCtx, openshiftNs)).To(Succeed())
+				nsCreated = true
+			}
+			defer func() {
+				if nsCreated {
+					_ = adminClient.Delete(testCtx, openshiftNs)
+				}
+			}()
+
+			ginkgo.By("Attempting to create a MustGather CR in the bare openshift namespace")
+			mg := &mustgatherv1.MustGather{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      mustGatherName,
+					Namespace: "openshift",
+				},
+				Spec: mustgatherv1.MustGatherSpec{
+					ServiceAccountName: "default",
+				},
+			}
+			assertRejectedWithNoWorkloads("openshift", "openshift", adminClient.Create(testCtx, mg))
+		})
+
+		ginkgo.It("should reject MustGather creation in bare kube namespace", func() {
+			kubeNs := &corev1.Namespace{}
+			nsCreated := false
+
+			ginkgo.By("Ensuring the kube namespace exists")
+			err := adminClient.Get(testCtx, client.ObjectKey{Name: "kube"}, kubeNs)
+			if apierrors.IsNotFound(err) {
+				kubeNs = &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{Name: "kube"},
+				}
+				Expect(adminClient.Create(testCtx, kubeNs)).To(Succeed())
+				nsCreated = true
+			}
+			defer func() {
+				if nsCreated {
+					_ = adminClient.Delete(testCtx, kubeNs)
+				}
+			}()
+
+			ginkgo.By("Attempting to create a MustGather CR in the bare kube namespace")
+			mg := &mustgatherv1.MustGather{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      mustGatherName,
+					Namespace: "kube",
+				},
+				Spec: mustgatherv1.MustGatherSpec{
+					ServiceAccountName: "default",
+				},
+			}
+			assertRejectedWithNoWorkloads("kube", "kube", adminClient.Create(testCtx, mg))
+		})
+
+		ginkgo.It("should reject MustGather creation in bare hypershift namespace", func() {
+			hypershiftNs := &corev1.Namespace{}
+			nsCreated := false
+
+			ginkgo.By("Ensuring the hypershift namespace exists")
+			err := adminClient.Get(testCtx, client.ObjectKey{Name: "hypershift"}, hypershiftNs)
+			if apierrors.IsNotFound(err) {
+				hypershiftNs = &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{Name: "hypershift"},
+				}
+				Expect(adminClient.Create(testCtx, hypershiftNs)).To(Succeed())
+				nsCreated = true
+			}
+			defer func() {
+				if nsCreated {
+					_ = adminClient.Delete(testCtx, hypershiftNs)
+				}
+			}()
+
+			ginkgo.By("Attempting to create a MustGather CR in the bare hypershift namespace")
+			mg := &mustgatherv1.MustGather{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      mustGatherName,
+					Namespace: "hypershift",
+				},
+				Spec: mustgatherv1.MustGatherSpec{
+					ServiceAccountName: "default",
+				},
+			}
+			assertRejectedWithNoWorkloads("hypershift", "hypershift", adminClient.Create(testCtx, mg))
+		})
+
+	})
+
 	ginkgo.Context("Directory Naming Convention Tests", func() {
 		var mustGatherName string
 		var mustGatherCR *mustgatherv1.MustGather
@@ -3902,14 +4155,14 @@ var _ = ginkgo.Describe("MustGather resource", ginkgo.Ordered, func() {
 
 	ginkgo.Context("Obfuscation CRD Validation Tests", func() {
 		ginkgo.It("should reject obfuscate.enabled without uploadTarget, source, or storage", func() {
-			mg := &mustgatherv1alpha1.MustGather{
+			mg := &mustgatherv1.MustGather{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      fmt.Sprintf("obf-val-no-target-%d", time.Now().UnixNano()),
 					Namespace: ns.Name,
 				},
-				Spec: mustgatherv1alpha1.MustGatherSpec{
+				Spec: mustgatherv1.MustGatherSpec{
 					ServiceAccountName: serviceAccount,
-					Obfuscate: &mustgatherv1alpha1.ObfuscateConfig{
+					Obfuscate: &mustgatherv1.ObfuscateConfig{
 						Enabled: func() *bool { b := true; return &b }(),
 					},
 				},
@@ -3920,16 +4173,16 @@ var _ = ginkgo.Describe("MustGather resource", ginkgo.Ordered, func() {
 		})
 
 		ginkgo.It("should reject obfuscate.source without enabled", func() {
-			mg := &mustgatherv1alpha1.MustGather{
+			mg := &mustgatherv1.MustGather{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      fmt.Sprintf("obf-val-src-no-en-%d", time.Now().UnixNano()),
 					Namespace: ns.Name,
 				},
-				Spec: mustgatherv1alpha1.MustGatherSpec{
+				Spec: mustgatherv1.MustGatherSpec{
 					ServiceAccountName: serviceAccount,
-					Obfuscate: &mustgatherv1alpha1.ObfuscateConfig{
-						Source: &mustgatherv1alpha1.PersistentVolumeConfig{
-							Claim: mustgatherv1alpha1.PersistentVolumeClaimReference{Name: mustGatherPVCName},
+					Obfuscate: &mustgatherv1.ObfuscateConfig{
+						Source: &mustgatherv1.PersistentVolumeConfig{
+							Claim: mustgatherv1.PersistentVolumeClaimReference{Name: mustGatherPVCName},
 						},
 					},
 				},
@@ -3940,17 +4193,17 @@ var _ = ginkgo.Describe("MustGather resource", ginkgo.Ordered, func() {
 		})
 
 		ginkgo.It("should reject obfuscate.source without uploadTarget", func() {
-			mg := &mustgatherv1alpha1.MustGather{
+			mg := &mustgatherv1.MustGather{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      fmt.Sprintf("obf-val-src-no-upload-%d", time.Now().UnixNano()),
 					Namespace: ns.Name,
 				},
-				Spec: mustgatherv1alpha1.MustGatherSpec{
+				Spec: mustgatherv1.MustGatherSpec{
 					ServiceAccountName: serviceAccount,
-					Obfuscate: &mustgatherv1alpha1.ObfuscateConfig{
+					Obfuscate: &mustgatherv1.ObfuscateConfig{
 						Enabled: func() *bool { b := true; return &b }(),
-						Source: &mustgatherv1alpha1.PersistentVolumeConfig{
-							Claim: mustgatherv1alpha1.PersistentVolumeClaimReference{Name: mustGatherPVCName},
+						Source: &mustgatherv1.PersistentVolumeConfig{
+							Claim: mustgatherv1.PersistentVolumeClaimReference{Name: mustGatherPVCName},
 						},
 					},
 				},
@@ -3961,18 +4214,18 @@ var _ = ginkgo.Describe("MustGather resource", ginkgo.Ordered, func() {
 		})
 
 		ginkgo.It("should reject obfuscate.source combined with imageStreamRef", func() {
-			mg := &mustgatherv1alpha1.MustGather{
+			mg := &mustgatherv1.MustGather{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      fmt.Sprintf("obf-val-src-imgref-%d", time.Now().UnixNano()),
 					Namespace: ns.Name,
 				},
-				Spec: mustgatherv1alpha1.MustGatherSpec{
+				Spec: mustgatherv1.MustGatherSpec{
 					ServiceAccountName: serviceAccount,
-					ImageStreamRef:     &mustgatherv1alpha1.ImageStreamTagRef{Name: "some-is", Tag: "latest"},
-					Obfuscate: &mustgatherv1alpha1.ObfuscateConfig{
+					ImageStreamRef:     &mustgatherv1.ImageStreamTagRef{Name: "some-is", Tag: "latest"},
+					Obfuscate: &mustgatherv1.ObfuscateConfig{
 						Enabled: func() *bool { b := true; return &b }(),
-						Source: &mustgatherv1alpha1.PersistentVolumeConfig{
-							Claim: mustgatherv1alpha1.PersistentVolumeClaimReference{Name: mustGatherPVCName},
+						Source: &mustgatherv1.PersistentVolumeConfig{
+							Claim: mustgatherv1.PersistentVolumeClaimReference{Name: mustGatherPVCName},
 						},
 					},
 				},
@@ -3983,20 +4236,20 @@ var _ = ginkgo.Describe("MustGather resource", ginkgo.Ordered, func() {
 		})
 
 		ginkgo.It("should reject empty obfuscationConfigRef.name", func() {
-			mg := &mustgatherv1alpha1.MustGather{
+			mg := &mustgatherv1.MustGather{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      fmt.Sprintf("obf-val-empty-cfgref-%d", time.Now().UnixNano()),
 					Namespace: ns.Name,
 				},
-				Spec: mustgatherv1alpha1.MustGatherSpec{
+				Spec: mustgatherv1.MustGatherSpec{
 					ServiceAccountName: serviceAccount,
-					Storage: &mustgatherv1alpha1.Storage{
-						Type: mustgatherv1alpha1.StorageTypePersistentVolume,
-						PersistentVolume: mustgatherv1alpha1.PersistentVolumeConfig{
-							Claim: mustgatherv1alpha1.PersistentVolumeClaimReference{Name: mustGatherPVCName},
+					Storage: &mustgatherv1.Storage{
+						Type: mustgatherv1.StorageTypePersistentVolume,
+						PersistentVolume: mustgatherv1.PersistentVolumeConfig{
+							Claim: mustgatherv1.PersistentVolumeClaimReference{Name: mustGatherPVCName},
 						},
 					},
-					Obfuscate: &mustgatherv1alpha1.ObfuscateConfig{
+					Obfuscate: &mustgatherv1.ObfuscateConfig{
 						Enabled:              func() *bool { b := true; return &b }(),
 						ObfuscationConfigRef: &corev1.LocalObjectReference{Name: ""},
 					},


### PR DESCRIPTION
Manual cherry-pick of #371 onto release-5.0.

The openshift-cherrypick-robot `/cherry-pick release-5.0` command failed due to a merge conflict in `deploy/02_must-gather-operator.ClusterRole.yaml`. This PR applies commit 896cb571 cleanly on top of current `release-5.0`.

## Summary

Adds a ValidatingAdmissionPolicy (VAP) that blocks creation of `MustGather` CRs in restricted infrastructure namespaces: `openshift`, `openshift-*`, `kube`, `kube-*`, `hypershift`, and `hypershift-*`.

## Changes

- New `admission_policy.go` + unit tests
- VAP startup runnable in controller `SetupWithManager`
- RBAC for `validatingadmissionpolicies` / `validatingadmissionpolicybindings` in ClusterRole and CSV
- E2E namespace restriction tests

## Test plan

- [x] `go test ./controllers/mustgather/...` passes locally
- [ ] CI green on release-5.0 branch

Fixes: https://issues.redhat.com/browse/MG-183