### PR TITLE
MG-357: Validate gather success before upload runs

### DIFF
--- a/controllers/mustgather/constant.go
+++ b/controllers/mustgather/constant.go
@@ -38,8 +38,14 @@ const (
 	obfuscateConfigMountPath  = "/etc/must-gather-clean/custom-config/config.yaml"
 	obfuscateConfigMapKey     = "config.yaml"
 
+	// gatherSuccessMarkerPath is the path to the marker file that the gather container
+	// writes on successful completion. The upload container checks for this file before
+	// proceeding with obfuscation or SFTP upload.
+	gatherSuccessMarkerPath = "/must-gather/.gather-success"
+
 	// obfuscateChownSuffix transfers gather output ownership to the upload container UID (65534).
-	// Captures the gather exit status first, runs chown (|| true so non-root images don't
-	// cause retries), then exits with the original status so gather failures propagate.
-	obfuscateChownSuffix = "gather_rc=$?; chown -R 65534:65534 /must-gather || true; exit $gather_rc"
+	// Captures the gather exit status first, writes the success marker on zero exit,
+	// runs chown (|| true so non-root images don't cause retries), then exits with
+	// the original status so gather failures propagate.
+	obfuscateChownSuffix = "gather_rc=$?; if [ $gather_rc -eq 0 ]; then touch " + gatherSuccessMarkerPath + "; fi; chown -R 65534:65534 /must-gather || true; exit $gather_rc"
 )

--- a/controllers/mustgather/template.go
+++ b/controllers/mustgather/template.go
@@ -30,7 +30,7 @@ const (
 
 	gatherCommandBinaryAudit   = "gather_audit_logs"
 	gatherCommandBinaryNoAudit = "gather"
-	gatherCommand              = "timeout %v bash -x -c -- '/usr/bin/%v' 2>&1 | tee /must-gather/must-gather.log\n\nstatus=$?\nif [[ $status -eq 124 || $status -eq 137 ]]; then\n  echo \"Gather timed out.\"\n  exit 0\nfi | tee -a /must-gather/must-gather.log"
+	gatherCommand              = "set -o pipefail\ntimeout %v bash -x -c -- '/usr/bin/%v' 2>&1 | tee /must-gather/must-gather.log\nstatus=${PIPESTATUS[0]}\nif [[ $status -eq 124 || $status -eq 137 ]]; then\n  echo \"Gather timed out.\" | tee -a /must-gather/must-gather.log\n  touch " + gatherSuccessMarkerPath + "\n  exit 0\nfi\nif [[ $status -ne 0 ]]; then\n  exit $status\nfi\ntouch " + gatherSuccessMarkerPath
 	gatherContainerName        = "gather"
 
 	// Environment variables for time-based log filtering
@@ -50,7 +50,9 @@ const (
 	uploadEnvMustGatherOutput = "must_gather_output"
 	uploadEnvMustGatherUpload = "must_gather_upload"
 	uploadEnvFilenamePrefix   = "FILENAME_PREFIX"
-	uploadCommand             = "count=0\nuntil [ $count -gt 4 ]\ndo\n  while `pgrep -a gather > /dev/null`\n  do\n    echo \"waiting for gathers to complete ...\"\n    sleep 120\n    count=0\n  done\n  echo \"no gather is running ($count / 4)\"\n  ((count++))\n  sleep 30\ndone\n/usr/local/bin/upload"
+	uploadCommand             = "count=0\nuntil [ $count -gt 4 ]\ndo\n  while `pgrep -a gather > /dev/null`\n  do\n    echo \"waiting for gathers to complete ...\"\n    sleep 120\n    count=0\n  done\n  echo \"no gather is running ($count / 4)\"\n  ((count++))\n  sleep 30\ndone\nif [ ! -f " + gatherSuccessMarkerPath + " ]; then\n  echo \"Error: gather did not complete successfully. Skipping upload.\"\n  exit 1\nfi\n/usr/local/bin/upload"
+
+	gatherSuccessMarkerSuffix = "rc=$?; if [ $rc -eq 0 ]; then touch " + gatherSuccessMarkerPath + "; fi; exit $rc"
 	uploadCommandDirect       = "/usr/local/bin/upload"
 
 	// SSH directory and known hosts file
@@ -347,10 +349,12 @@ func getGatherContainer(image string, audit bool, timeout time.Duration, storage
 			allArgs = append(allArgs, args...)
 			container.Args = allArgs
 		} else {
-			container.Command = command
-			if len(args) > 0 {
-				container.Args = args
-			}
+			wrappedCmd := "\"$@\"\n" + gatherSuccessMarkerSuffix
+			container.Command = []string{"/bin/bash", "-c", wrappedCmd, "--"}
+			allArgs := make([]string, 0, len(command)+len(args))
+			allArgs = append(allArgs, command...)
+			allArgs = append(allArgs, args...)
+			container.Args = allArgs
 		}
 	} else {
 		gatherCmd := fmt.Sprintf(gatherCommand, math.Ceil(timeout.Seconds()), commandBinary)

--- a/controllers/mustgather/template_test.go
+++ b/controllers/mustgather/template_test.go
@@ -233,15 +233,31 @@ func Test_getGatherContainer(t *testing.T) {
 					t.Fatalf("gather container command expected with binary %v but it wasn't present", gatherCommandBinaryNoAudit)
 				}
 				timeoutInSeconds := int(math.Ceil(tt.timeout.Seconds()))
-				if !strings.HasPrefix(containerCommand, fmt.Sprintf("timeout %d", timeoutInSeconds)) {
-					t.Fatalf("the duration was not properly added to the container command, got %v but wanted %v", strings.Split(containerCommand, " ")[1], timeoutInSeconds)
+				if !strings.Contains(containerCommand, fmt.Sprintf("timeout %d", timeoutInSeconds)) {
+					t.Fatalf("the duration was not present in the container command, got %v but wanted timeout %v", containerCommand, timeoutInSeconds)
+				}
+				if !strings.Contains(containerCommand, "set -o pipefail") {
+					t.Fatalf("expected pipefail in gather command, got %v", containerCommand)
+				}
+				if !strings.Contains(containerCommand, gatherSuccessMarkerPath) {
+					t.Fatalf("expected success marker path in gather command, got %v", containerCommand)
 				}
 			} else {
-				if !reflect.DeepEqual(container.Command, tt.command) {
-					t.Fatalf("expected container command %v but got %v", tt.command, container.Command)
+				if container.Command[0] != "/bin/bash" || container.Command[1] != "-c" {
+					t.Fatalf("expected custom command to be wrapped in bash, got %v", container.Command)
 				}
-				if !reflect.DeepEqual(container.Args, tt.args) {
-					t.Fatalf("expected container args %v but got %v", tt.args, container.Args)
+				wrappedScript := container.Command[2]
+				if !strings.Contains(wrappedScript, "\"$@\"") {
+					t.Fatalf("expected wrapped script to contain \"$@\" passthrough, got %q", wrappedScript)
+				}
+				if !strings.Contains(wrappedScript, gatherSuccessMarkerPath) {
+					t.Fatalf("expected success marker in wrapped custom command, got %q", wrappedScript)
+				}
+				expectedArgs := make([]string, 0, len(tt.command)+len(tt.args))
+				expectedArgs = append(expectedArgs, tt.command...)
+				expectedArgs = append(expectedArgs, tt.args...)
+				if !reflect.DeepEqual(container.Args, expectedArgs) {
+					t.Fatalf("expected container args %v but got %v", expectedArgs, container.Args)
 				}
 			}
 
@@ -665,8 +681,8 @@ func Test_getJobTemplate_ProxyAuditTimeout(t *testing.T) {
 					t.Fatalf("expected gather command to contain %v but got %v", gatherCommandBinaryNoAudit, gatherCmd)
 				}
 			}
-			if !strings.HasPrefix(gatherCmd, tt.wantTimeout) {
-				t.Fatalf("expected gather command to start with %q but got %q", tt.wantTimeout, gatherCmd)
+			if !strings.Contains(gatherCmd, tt.wantTimeout) {
+				t.Fatalf("expected gather command to contain %q but got %q", tt.wantTimeout, gatherCmd)
 			}
 
 			upload := findUploadContainerInJob(t, job)
@@ -1051,8 +1067,18 @@ func Test_getGatherContainer_ChownSuffix(t *testing.T) {
 	}
 
 	containerCustomCmdNoObfuscate := getGatherContainer("img", false, 5*time.Second, nil, "", nil, []string{"/custom"}, nil, "", nil)
-	if len(containerCustomCmdNoObfuscate.Command) != 1 || containerCustomCmdNoObfuscate.Command[0] != "/custom" {
-		t.Fatalf("expected custom command to be preserved without obfuscate, got %v", containerCustomCmdNoObfuscate.Command)
+	if len(containerCustomCmdNoObfuscate.Command) != 4 || containerCustomCmdNoObfuscate.Command[0] != "/bin/bash" {
+		t.Fatalf("expected custom command without obfuscate to be wrapped in bash for success marker, got %v", containerCustomCmdNoObfuscate.Command)
+	}
+	wrappedScriptNoObfuscate := containerCustomCmdNoObfuscate.Command[2]
+	if !strings.Contains(wrappedScriptNoObfuscate, `"$@"`) {
+		t.Fatalf("expected wrapped script to contain \"$@\" passthrough, got %q", wrappedScriptNoObfuscate)
+	}
+	if !strings.Contains(wrappedScriptNoObfuscate, gatherSuccessMarkerPath) {
+		t.Fatalf("expected success marker in wrapped custom command, got %q", wrappedScriptNoObfuscate)
+	}
+	if strings.Contains(wrappedScriptNoObfuscate, "chown") {
+		t.Fatalf("expected no chown suffix without obfuscate, got %q", wrappedScriptNoObfuscate)
 	}
 }
 
@@ -1187,4 +1213,163 @@ func envValues(container v1.Container) map[string]string {
 		m[e.Name] = e.Value
 	}
 	return m
+}
+
+func Test_gatherCommand_exitCodePropagation(t *testing.T) {
+	container := getGatherContainer("img", false, 300*time.Second, nil, "", nil, nil, nil, "", nil)
+	gatherCmd := container.Command[2]
+
+	if !strings.Contains(gatherCmd, "set -o pipefail") {
+		t.Fatal("gatherCommand must include pipefail to prevent tee from masking gather exit codes")
+	}
+	if !strings.Contains(gatherCmd, "${PIPESTATUS[0]}") {
+		t.Fatal("gatherCommand must use PIPESTATUS[0] to capture the gather exit code, not tee's exit code")
+	}
+	if !strings.Contains(gatherCmd, "exit $status") {
+		t.Fatal("gatherCommand must propagate non-zero exit codes via exit $status")
+	}
+}
+
+func Test_gatherCommand_successMarker(t *testing.T) {
+	tests := []struct {
+		name      string
+		command   []string
+		args      []string
+		obfuscate *mustgatherv1.ObfuscateConfig
+	}{
+		{
+			name: "default command writes success marker",
+		},
+		{
+			name:    "custom command writes success marker",
+			command: []string{"/usr/bin/custom-gather"},
+			args:    []string{"--verbose"},
+		},
+		{
+			name:      "default command with obfuscate writes success marker",
+			obfuscate: &mustgatherv1.ObfuscateConfig{Enabled: ToPtr(true)},
+		},
+		{
+			name:      "custom command with obfuscate writes success marker",
+			command:   []string{"/usr/bin/custom-gather"},
+			obfuscate: &mustgatherv1.ObfuscateConfig{Enabled: ToPtr(true)},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			container := getGatherContainer("img", false, 5*time.Second, nil, "", nil, tt.command, tt.args, "", tt.obfuscate)
+			script := container.Command[2]
+			if !strings.Contains(script, gatherSuccessMarkerPath) {
+				t.Fatalf("gather command must write success marker at %s, got:\n%s", gatherSuccessMarkerPath, script)
+			}
+		})
+	}
+}
+
+func Test_gatherCommand_timeoutWritesMarker(t *testing.T) {
+	container := getGatherContainer("img", false, 300*time.Second, nil, "", nil, nil, nil, "", nil)
+	gatherCmd := container.Command[2]
+
+	timeoutIdx := strings.Index(gatherCmd, "124 || $status -eq 137")
+	if timeoutIdx == -1 {
+		t.Fatal("expected timeout handling for exit codes 124/137")
+	}
+	timeoutBlock := gatherCmd[timeoutIdx:]
+	exitIdx := strings.Index(timeoutBlock, "exit 0")
+	markerIdx := strings.Index(timeoutBlock, gatherSuccessMarkerPath)
+	if markerIdx == -1 || markerIdx > exitIdx {
+		t.Fatal("success marker must be written before exit 0 in the timeout block")
+	}
+}
+
+func Test_uploadCommand_gatherSuccessGate(t *testing.T) {
+	t.Setenv(DefaultMustGatherImageEnv, "quay.io/foo/bar/must-gather:latest")
+
+	mg := mustgatherv1.MustGather{
+		ObjectMeta: metav1.ObjectMeta{Name: "mg", Namespace: "ns"},
+		Spec: mustgatherv1.MustGatherSpec{
+			ServiceAccountName: "default",
+			UploadTarget: &mustgatherv1.UploadTargetSpec{
+				Type: mustgatherv1.UploadTypeSFTP,
+				SFTP: &mustgatherv1.SFTPSpec{
+					CaseID: "1234",
+					Host:   ptr.To("sftp.example.com"),
+					CaseManagementAccountSecretRef: v1.LocalObjectReference{
+						Name: "case-mgmt-secret",
+					},
+				},
+			},
+		},
+	}
+
+	job := getJobTemplate("img", "operator-image", mg, "", "must-gather.local.test.20240101T120000Z.000001")
+	upload := findUploadContainerInJob(t, job)
+	uploadCmd := upload.Command[2]
+
+	if !strings.Contains(uploadCmd, gatherSuccessMarkerPath) {
+		t.Fatalf("upload command must check for gather success marker at %s, got:\n%s", gatherSuccessMarkerPath, uploadCmd)
+	}
+	if !strings.Contains(uploadCmd, "Skipping upload") {
+		t.Fatal("upload command must log a message when skipping upload due to missing success marker")
+	}
+	if !strings.Contains(uploadCmd, "exit 1") {
+		t.Fatal("upload command must exit 1 when gather success marker is missing")
+	}
+
+	markerCheckIdx := strings.Index(uploadCmd, gatherSuccessMarkerPath)
+	uploadCallIdx := strings.Index(uploadCmd, "/usr/local/bin/upload")
+	if markerCheckIdx > uploadCallIdx {
+		t.Fatal("marker check must occur before the upload script call")
+	}
+}
+
+func Test_uploadCommand_sourceMode_noGatherGate(t *testing.T) {
+	t.Setenv(DefaultMustGatherImageEnv, "quay.io/foo/bar/must-gather:latest")
+
+	mg := mustgatherv1.MustGather{
+		ObjectMeta: metav1.ObjectMeta{Name: "mg", Namespace: "ns"},
+		Spec: mustgatherv1.MustGatherSpec{
+			ServiceAccountName: "default",
+			Obfuscate: &mustgatherv1.ObfuscateConfig{
+				Enabled: ToPtr(true),
+				Source: &mustgatherv1.PersistentVolumeConfig{
+					Claim: mustgatherv1.PersistentVolumeClaimReference{Name: "existing-pvc"},
+				},
+			},
+		},
+	}
+
+	job := getJobTemplate("img", "operator-image", mg, "", "dir-name")
+	upload := findUploadContainerInJob(t, job)
+	uploadCmd := upload.Command[2]
+
+	if strings.Contains(uploadCmd, gatherSuccessMarkerPath) {
+		t.Fatal("source mode must not check for gather success marker (no gather container)")
+	}
+	if !strings.Contains(uploadCmd, uploadCommandDirect) {
+		t.Fatal("source mode must use direct upload command")
+	}
+}
+
+func Test_uploadCommand_obfuscateOnly_gatherSuccessGate(t *testing.T) {
+	t.Setenv(DefaultMustGatherImageEnv, "quay.io/foo/bar/must-gather:latest")
+
+	mg := mustgatherv1.MustGather{
+		ObjectMeta: metav1.ObjectMeta{Name: "mg", Namespace: "ns"},
+		Spec: mustgatherv1.MustGatherSpec{
+			ServiceAccountName: "default",
+			Obfuscate: &mustgatherv1.ObfuscateConfig{
+				Enabled: ToPtr(true),
+			},
+		},
+	}
+
+	job := getJobTemplate("img", "operator-image", mg, "", "dir-name")
+	upload := findUploadContainerInJob(t, job)
+	uploadCmd := upload.Command[2]
+
+	if !strings.Contains(uploadCmd, gatherSuccessMarkerPath) {
+		t.Fatal("obfuscate-only mode (with gather) must check for gather success marker")
+	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Must-gather uploads are now skipped when gathering fails.
  * Gather failures correctly preserve and report their exit status.
  * Timeout scenarios are handled consistently, allowing eligible timed-out gathers to proceed with upload.
  * Custom gather commands and arguments are executed and forwarded correctly.
  * Uploads now wait for confirmation that gathering completed successfully.
  * Stale success indicators are cleared before new gathers, preventing uploads of incomplete results.

* **Tests**
  * Expanded coverage for failures, timeouts, custom commands, and upload eligibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->